### PR TITLE
Implement AbstractLogger interface

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,4 +15,3 @@ script:
     - julia --color=yes -e 'using Pkg; Pkg.activate(); Pkg.instantiate(); Pkg.test()';
 after_success:
     - julia -e 'using Pkg; cd(Pkg.dir("TensorBoardLogger")); Pkg.add("Coverage"); using Coverage; Codecov.submit(Codecov.process_folder())'
-    - julia -e 'using Pkg; cd(Pkg.dir("TensorBoardLogger")); Pkg.add("Coverage"); using Coverage; Coveralls.submit(Coveralls.process_folder())';

--- a/Project.toml
+++ b/Project.toml
@@ -5,6 +5,7 @@ version = "0.1.0"
 
 [deps]
 CRC32c = "8bf52ea8-c179-5cab-976a-9e18b702a9bc"
+DataStructures = "864edb3b-99cc-5e75-8d2d-829cb0a9cfe8"
 ProtoBuf = "3349acd9-ac6a-5e09-bcdb-63829b23a429"
 StatsBase = "2913bbd2-ae8a-5f71-8c99-4fb6c76f3a91"
 

--- a/Project.toml
+++ b/Project.toml
@@ -5,7 +5,6 @@ version = "0.1.0"
 
 [deps]
 CRC32c = "8bf52ea8-c179-5cab-976a-9e18b702a9bc"
-DataStructures = "864edb3b-99cc-5e75-8d2d-829cb0a9cfe8"
 ProtoBuf = "3349acd9-ac6a-5e09-bcdb-63829b23a429"
 StatsBase = "2913bbd2-ae8a-5f71-8c99-4fb6c76f3a91"
 

--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ with_logger(lg) do
 
 
         @info "test" i=i j=i^2 dd=rand(10).+0.1*i hh=data_tuple
-        @info "test_2" i=i j=2^i hh=data_tuple delta_step=0
+        @info "test_2" i=i j=2^i hh=data_tuple log_step_increment=0
     end
 end
 ```

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ and from [TensorBoardX](https://tensorboardx.readthedocs.io/en/latest/).
 
 To use the library you must create a `Logger` object and then log data to it.
 
-  - `Logger(dir_path)` creates a logger saving data to the folder `dir_path`
+  - `TBLogger(dir_path)` creates a logger saving data to the folder `dir_path`
   - `log_value(logger, name, val)` logs to `logger` the value `val` under the tag `name`
 
 ## Supported values
@@ -25,25 +25,22 @@ At the moment, you can log the following values:
 
 ## Example
 ```
-using TensorBoardLogger
+using TensorBoardLogger, Logging, Random
 
-lg = Logger("runs/run-12", overwrite=true)
+lg=TBLogger()
 
-for step=1:100
-    ev = log_value(lg, "quan/prova1", step*1.5, step=step)
-    ev = log_value(lg, "quan/prova2", step*2.5, step=step)
+with_logger(lg) do
+    for i=1:100
+        x0 = 0.5+i/30; s0 = 0.5/(i/20);
+        edges = collect(-5:0.1:5)
+        centers = collect(edges[1:end-1] .+0.05)
+        histvals = [exp(-((c-x0)/s0)^2) for c=centers]
+        data_tuple = (edges, histvals)
 
-    x0 = 0.5+step/30; s0 = 0.5/(step/20);
-    edges = collect(-5:0.1:5)
-    centers = collect(edges[1:end-1] .+0.05)
-    histvals = [exp(-((c-x0)/s0)^2) for c=centers]
-    histvals./=sum(histvals)
-    data_tuple = (edges, histvals)
 
-    # Log pre-binned data
-    log_histogram(lg, "hist/cust", data_tuple, step=step)
-    # Automatically bin the data
-    log_histogram(lg, "hist/auto", randn(1000).*s0.+x0, step=step)
+        @info "test" i=i j=i^2 dd=rand(10).+0.1*i hh=data_tuple
+        @info "test_2" i=i j=2^i hh=data_tuple delta_step=0
+    end
 end
 ```
 

--- a/src/Logger.jl
+++ b/src/Logger.jl
@@ -6,7 +6,7 @@ deletes previously created events.
 If `purge_step::Int` is passed, every step before `purge_step` will be ignored
 by tensorboard (usefull in the case of restarting a crashed computation).
 """
-function Logger(logdir; overwrite=false, time=time(), purge_step::Union{Int,Nothing}=nothing)
+function TBLogger(logdir; overwrite=false, time=time(), purge_step::Union{Int,Nothing}=nothing)
     if overwrite
         rm(logdir; force=true, recursive=true)
     end
@@ -33,11 +33,11 @@ function Logger(logdir; overwrite=false, time=time(), purge_step::Union{Int,Noth
         write_event(file, ev_0)
     end
 
-    Logger(realpath(logdir), file, all_files, start_step)
+    TBLogger(realpath(logdir), file, all_files, start_step, Info)
 end
 
 # normally the logs don't overwrite, but if you've not given a path, you clearly don't care.
-Logger() = Logger("tensorboard_logs", overwrite=true)
+TBLogger() = TBLogger("tensorboard_logs", overwrite=true)
 
 # Accessors
 """
@@ -45,15 +45,15 @@ Logger() = Logger("tensorboard_logs", overwrite=true)
 
 Returns the directory to which Logger `lg` is writing data.
 """
-logdir(lg::Logger)   = lg.logdir
+logdir(lg::TBLogger)   = lg.logdir
 
 """
     get_file(lg::Logger) -> IOS
 
 Returns the main `file` IOStream object of Logger `lg`.
 """
-get_file(lg::Logger) = lg.file
-function add_log_file(lg::Logger, path::String)
+get_file(lg::TBLogger) = lg.file
+function add_log_file(lg::TBLogger, path::String)
     file = open(path, "w")
     lg.all_files[path] = file
     return file
@@ -65,7 +65,7 @@ end
 Returns the `file` IOStream object of Logger `lg` writing to the tag
 `tags1/tags2.../tagsN`.
 """
-function get_file(lg::Logger, tags::String...)
+function get_file(lg::TBLogger, tags::String...)
     key = joinpath(logdir(lg), tags...)
     if key ∈ lg.all_files
         return lg.all_files[key]
@@ -80,7 +80,7 @@ end
 Sets the iteration counter in the logger to `iter`. This counter is used by the
 logger when no value is passed by the user.
 """
-set_step(lg::Logger, iter::Int) = lg.global_step = iter
+set_step(lg::TBLogger, iter::Int) = lg.global_step = iter
 
 """
     iteration(lg)
@@ -88,7 +88,7 @@ set_step(lg::Logger, iter::Int) = lg.global_step = iter
 Returns the internal iteration counter of the logger. When no step keyword
 is provided to the loggers, it will use this value.
 """
-step(lg::Logger) = lg.global_step
+step(lg::TBLogger) = lg.global_step
 
 
 # Additional things

--- a/src/Logger.jl
+++ b/src/Logger.jl
@@ -167,8 +167,11 @@ function preprocess(name, val::T, data) where T
             prop = getproperty(val, f)
             preprocess(name*"/$f", val, data)
         end
-    else
-        throw(ErrorException("Can't log type $T, but can't preprocess it either.\n You should define preprocess(name, val::$T, data)."))
+
+    #TODO If you encounter something that can't be logged, silently drop it.
+    # When String/text logging will be implemented we should use it as a fallback.
+    #else
+    #    throw(ErrorException("Can't log type $T, but can't preprocess it either.\n You should define preprocess(name, val::$T, data)."))
     end
     data
 end

--- a/src/Loggers/LogHistograms.jl
+++ b/src/Loggers/LogHistograms.jl
@@ -8,7 +8,7 @@ passed as a tuple holding the `N+1` bin edges and the height of the `N` bins.
 You can also pass the raw data, and a binning algorithm from `StatsBase.jl` will
 be used to bin the data.
 """
-function log_histogram(logger::Logger, name::String, (bins,weights)::Tuple{Vector,Vector};
+function log_histogram(logger::TBLogger, name::String, (bins,weights)::Tuple{Vector,Vector};
                        step=nothing)
     summ    = SummaryCollection()
     push!(summ.value,  histogram_summary(name, bins, weights))
@@ -21,7 +21,7 @@ end
 Bins the values found in `data` and logs them as an histogram under the tag
 `name`.
 """
-function log_histogram(logger::Logger, name::String, data::Vector;
+function log_histogram(logger::TBLogger, name::String, data::Vector;
                        step=nothing)
     summ    = SummaryCollection()
     hvals = fit(Histogram, data)
@@ -34,7 +34,7 @@ end
 
 Logs the vector found in `data` as an histogram under the name `name`.
 """
-function log_vector(logger::Logger, name::String, data::Vector; step=nothing)
+function log_vector(logger::TBLogger, name::String, data::Vector; step=nothing)
     summ    = SummaryCollection()
     push!(summ.value, histogram_summary(name, collect(0:length(data)),data))
     write_event(logger.file, make_event(logger, summ, step))

--- a/src/Loggers/LogHistograms.jl
+++ b/src/Loggers/LogHistograms.jl
@@ -59,3 +59,14 @@ end
 ## Backward compatibility
 log_histogram(logger, name, value, step) =
     log_histogram(logger, name, value; step=step)
+
+
+# Forward
+preprocess(name, val::AbstractVector, data) where T<:Complex = push!(data, name*"/re"=>real.(val), name*"/im"=>imag.(val))
+preprocess(name, val::AbstractArray, data) = push!(data, name=>vec(val))
+
+loggable(::AbstractVector{T}) where T<:Real = true
+summary_impl(name, val::AbstractVector) = histogram_summary(name, collect(0:length(val)),val)
+
+loggable(::Tuple{Vector,Vector}) = true
+summary_impl(name, (bins,weights)::Tuple{Vector,Vector}) = histogram_summary(name, bins, weights)

--- a/src/Loggers/LogValue.jl
+++ b/src/Loggers/LogValue.jl
@@ -10,8 +10,8 @@ function log_value(logger::TBLogger, name::String, value::Real; step=nothing)
 end
 
 function log_value(logger::TBLogger, name::String, value::Complex; step=nothing)
-    log_value(logger, name*"/re", real(value), step)
-    log_value(logger, name*"/im", imag(value), step)
+    log_value(logger, name*"/re", real(value), step=step)
+    log_value(logger, name*"/im", imag(value), step=step)
 end
 
 function scalar_summary(name::String, value::Real)

--- a/src/Loggers/LogValue.jl
+++ b/src/Loggers/LogValue.jl
@@ -18,11 +18,12 @@ function scalar_summary(name::String, value::Real)
     Summary_Value(tag=name, simple_value=value)
 end
 
-## Backward compatibility
-log_value(logger, name, value, step) =
-    log_value(logger, name, value, step=step)
 
-# Forward
-loggable(::Real) = true
-preprocess(name, val::Complex, data) = push!(data, name*"/re"=>real(val), name*"/im"=>imag(val))
+## Logger Interface
+
+# Define the type(s) that can be serialized to TensorBoard
+preprocess(name, val::Real, data) where T<:Real = push!(data, name=>val)
 summary_impl(name, value::Real) = scalar_summary(name, value)
+
+# Split complex numbers into real/complex pairs
+preprocess(name, val::Complex, data) = push!(data, name*"/re"=>real(val), name*"/im"=>imag(val))

--- a/src/Loggers/LogValue.jl
+++ b/src/Loggers/LogValue.jl
@@ -21,3 +21,8 @@ end
 ## Backward compatibility
 log_value(logger, name, value, step) =
     log_value(logger, name, value, step=step)
+
+# Forward
+loggable(::Real) = true
+preprocess(name, val::Complex, data) = push!(data, name*"/re"=>real(val), name*"/im"=>imag(val))
+summary_impl(name, value::Real) = scalar_summary(name, value)

--- a/src/Loggers/LogValue.jl
+++ b/src/Loggers/LogValue.jl
@@ -3,13 +3,13 @@
 
 Logs a Floating-point variable with name `name` at step `step`
 """
-function log_value(logger::Logger, name::String, value::Real; step=nothing)
+function log_value(logger::TBLogger, name::String, value::Real; step=nothing)
     summ    = SummaryCollection()
     push!(summ.value, scalar_summary(name, value))
     write_event(logger.file, make_event(logger, summ, step=step))
 end
 
-function log_value(logger::Logger, name::String, value::Complex; step=nothing)
+function log_value(logger::TBLogger, name::String, value::Complex; step=nothing)
     log_value(logger, name*"/re", real(value), step)
     log_value(logger, name*"/im", imag(value), step)
 end

--- a/src/TensorBoardLogger.jl
+++ b/src/TensorBoardLogger.jl
@@ -2,7 +2,6 @@ module TensorBoardLogger
 
 using ProtoBuf
 using CRC32c
-using DataStructures
 
 #TODO: remove it. Only needed to compute histogram bins.
 using StatsBase

--- a/src/TensorBoardLogger.jl
+++ b/src/TensorBoardLogger.jl
@@ -2,9 +2,18 @@ module TensorBoardLogger
 
 using ProtoBuf
 using CRC32c
+using DataStructures
 
 #TODO: remove it. Only needed to compute histogram bins.
 using StatsBase
+
+# Import Base methods for Logging
+using Base.CoreLogging:
+    global_logger, LogLevel, Info
+
+import Base.CoreLogging:
+    AbstractLogger, handle_message, shouldlog, min_enabled_level,
+	catch_exceptions
 
 # Protobuffer definitions for tensorboard
 include("protojl/tensorflow.jl")
@@ -20,6 +29,8 @@ mutable struct TBLogger <: AbstractLogger
     file::IOStream
     all_files::Dict{String, IOStream}
     global_step::Int
+
+	min_level::LogLevel
 end
 
 include("logging.jl")

--- a/src/TensorBoardLogger.jl
+++ b/src/TensorBoardLogger.jl
@@ -3,7 +3,7 @@ module TensorBoardLogger
 using ProtoBuf
 using CRC32c
 
-#TODO: remove it. Only needed to compute histogram bins. 
+#TODO: remove it. Only needed to compute histogram bins.
 using StatsBase
 
 # Protobuffer definitions for tensorboard
@@ -15,7 +15,7 @@ include("protojl/event_pb.jl")
 include("utils.jl")
 
 # Logging structures
-mutable struct Logger
+mutable struct TBLogger <: AbstractLogger
     logdir::String
     file::IOStream
     all_files::Dict{String, IOStream}
@@ -28,13 +28,9 @@ include("Loggers/LogHistograms.jl")
 include("Logger.jl")
 
 
-#macro tb_log(name)
-#    :(_tb_log($(esc(string(name))), $(esc(name))))
-#end
-
 export log_histogram, log_value, log_vector
 export scalar_summary, histogram_summary, make_event
-export Logger
+export TBLogger
 
 export set_tb_logdir, reset_tb_logs, default_logging_session
 

--- a/src/logging.jl
+++ b/src/logging.jl
@@ -2,7 +2,7 @@
 # protobuf is broken).
 const SummaryCollection(;kwargs...) = Summary(value=Base.Vector{Summary_Value}(); kwargs...)
 
-function make_event(logger::Logger, summary::Summary;
+function make_event(logger::TBLogger, summary::Summary;
                     step::Union{Nothing, Int}=nothing)
     # If the step is not set explicitly, get it from the logger
     if typeof(step) == Nothing
@@ -27,4 +27,4 @@ function write_event(file::IOStream, event::Event)
     flush(file)
 end
 
-write_event(logger::Logger, event::Event) = write_event(logger.file, event)
+write_event(logger::TBLogger, event::Event) = write_event(logger.file, event)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -2,7 +2,7 @@ using TensorBoardLogger
 using Test
 
 @testset "Scalar Value Logger" begin
-    logger = Logger("log/")
+    logger = TBLogger("log/")
     @test isdir("log/")
     step = 1
     log_value(logger, "float32", 1.25f0, step=step)
@@ -17,7 +17,7 @@ using Test
 end
 
 @testset "Histogram Value Logger" begin
-    logger = Logger("log/")
+    logger = TBLogger("log/")
     @test isdir("log/")
     step = 1
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,4 +1,4 @@
-using TensorBoardLogger
+using TensorBoardLogger, Logging
 using Test
 
 @testset "Scalar Value Logger" begin
@@ -24,4 +24,25 @@ end
 
     log_histogram(logger, "hist/cust", data_tuple, step=step)
     log_histogram(logger, "hist/cust", rand(100), step=step)
+end
+
+@testset "LogInterface" begin
+    logger = TBLogger("log/")
+    @test isdir("log/")
+
+    with_logger(logger) do
+        for i=1:100
+            x0 = 0.5+i/30; s0 = 0.5/(i/20);
+            edges = collect(-5:0.1:5)
+            centers = collect(edges[1:end-1] .+0.05)
+            histvals = [exp(-((c-x0)/s0)^2) for c=centers]
+            data_tuple = (edges, histvals)
+
+
+            @info "test" i=i j=i^2 dd=rand(10).+0.1*i hh=data_tuple
+            @info "test2" i=i j=2^i dd=rand(10).-0.1*i hh=data_tuple log_step_increment=0
+        end
+    end
+
+    @test TensorBoardLogger.step(logger) == 100
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -9,11 +9,6 @@ using Test
     log_value(logger, "float64", 1.5, step=step)
     log_value(logger, "irr", pi, step=step)
     log_value(logger, "complex", 1.0 + 1.0im, step=step)
-
-    log_value(logger, "float32", 1.25f0, step)
-    log_value(logger, "float64", 1.5, step)
-    log_value(logger, "irr", pi, step)
-    log_value(logger, "complex", 1.0 + 1.0im, step)
 end
 
 @testset "Histogram Value Logger" begin


### PR DESCRIPTION
Implements the logging interface.

Can break down arbitrary structs #5 into elementary blocks. 

This also exposes an API to allow other packages to edit how TensorBoardLogger logs custom types. 

To change how a custom type is logged, `preprocess(name::String, value::CustomType, data)` should be defined, pushing to `data` name-value pairs of objects that should be logged. For example, complex numbers are internally handled by the following `preprocess` function:
```
preprocess(name, val::Complex, data) = push!(data, name*"/re"=>real(val), 
                                                   name*"/im"=>imag(val))
```

If someone has a better idea for how to implement this interface, please feel free to share.