### PR TITLE
Wrapper type implementation

### DIFF
--- a/src/TensorBoardLogger.jl
+++ b/src/TensorBoardLogger.jl
@@ -12,6 +12,8 @@ export scalar_summary, histogram_summary, text_summary, make_event
 export TBLogger
 export reset!, set_step!, increment_step!
 
+# Wrapper types
+export TBText, TBVector, TBHistogram
 
 # Protobuffer definitions for tensorboard
 include("protojl/tensorflow.jl")
@@ -36,4 +38,5 @@ include("Loggers/LogValue.jl")
 include("Loggers/LogText.jl")
 include("Loggers/LogHistograms.jl")
 include("logger_dispatch.jl")
+include("logger_dispatch_overrides.jl")
 end # module

--- a/src/logger_dispatch.jl
+++ b/src/logger_dispatch.jl
@@ -13,7 +13,7 @@ For a struct, it calls preprocess on every field.
 """
 function preprocess(name, val::T, data) where T
     if isstructtype(T)
-        fn = fieldnames(T)
+        fn = tb_logged_propertynames(val)
         for f=fn
             prop = getfield(val, f)
             preprocess(name*"/$f", prop, data)
@@ -25,6 +25,18 @@ function preprocess(name, val::T, data) where T
     end
     data
 end
+
+"""
+    tb_logged_propertynames(val::Any)
+
+Returns a tuple with the name of the fields of the structure `val` that 
+should be logged to TensorBoard. This function should be overridden when
+you want TensorBoard to ignore some fields in a structure when logging 
+it. The default behaviour is to return the  same result as `propertynames`. 
+
+See also: [`Base.propertynames`](@ref)
+"""
+tb_logged_propertynames(val::Type) = propertynames(val)
 
 ## Default behaviours
 

--- a/src/logger_dispatch.jl
+++ b/src/logger_dispatch.jl
@@ -13,7 +13,7 @@ For a struct, it calls preprocess on every field.
 """
 function preprocess(name, val::T, data) where T
     if isstructtype(T)
-        fn = tb_logged_propertynames(val)
+        fn = logable_propertynames(val)
         for f=fn
             prop = getfield(val, f)
             preprocess(name*"/$f", prop, data)
@@ -27,7 +27,7 @@ function preprocess(name, val::T, data) where T
 end
 
 """
-    tb_logged_propertynames(val::Any)
+    logable_propertynames(val::Any)
 
 Returns a tuple with the name of the fields of the structure `val` that 
 should be logged to TensorBoard. This function should be overridden when
@@ -36,7 +36,7 @@ it. The default behaviour is to return the  same result as `propertynames`.
 
 See also: [`Base.propertynames`](@ref)
 """
-tb_logged_propertynames(val::Type) = propertynames(val)
+logable_propertynames(val::Type) = propertynames(val)
 
 ## Default behaviours
 
@@ -55,6 +55,7 @@ summary_impl(name, (bins,weights)::Tuple{AbstractVector,AbstractVector}) = histo
 # Split complex numbers into real/complex pairs
 preprocess(name, val::AbstractVector{<:Complex}, data) = push!(data, name*"/re"=>real.(val), name*"/im"=>imag.(val))
 preprocess(name, val::AbstractArray, data) = push!(data, name=>vec(val))
+
 
 ########## For things going to LogValue #############################
 preprocess(name, val::Real, data) = push!(data, name=>val)

--- a/src/logger_dispatch_overrides.jl
+++ b/src/logger_dispatch_overrides.jl
@@ -1,0 +1,60 @@
+## Overridden behaviours
+"""
+    WrapperLogType
+
+Abstract wrapper type to override the default backend to which a type would be
+logged in TensorBoard.
+
+Every concrete implementation should implement the method `content` for the
+concrete type, returning the content.
+"""
+abstract type WrapperLogType end
+
+"""
+    content(x::WrapperLogType)
+
+Returns the wrapped data inside of `x`.
+"""
+content(x::WrapperLogType) = @error "You should define `content($(typeof(x)))`"
+
+# When we hit a wrapped type, we dispatch based on it's type.
+preprocess(name, val::WrapperLogType, data) = push!(data, name=>val)
+
+# When logging to text or console, unwrap the LogType to fix formatting.
+Base.show(io::IO, mime::AbstractString, x::WrapperLogType) =
+    Base.show(io, mime, content(x))
+
+########## For things going to LogText ##############################
+"""
+    TBText(data)
+
+Forces `data` to be serialized as text to TensorBoard.
+"""
+struct TBText <: WrapperLogType data; end
+content(x::TBText) = x.data
+summary_impl(name, val::TBText) = text_summary(name, val.data)
+
+
+########## For things going to LogHistograms ########################
+"""
+    TBHistogram(data)
+
+Forces `data` to be serialized as an histogram to TensorBoard.
+"""
+struct TBHistogram <: WrapperLogType data::AbstractArray; end
+content(x::TBHistogram) = x.data
+function summary_impl(name, val::TBHistogram)
+    hvals = fit(Histogram, val.data)
+    return histogram_summary(name, collect(hvals.edges[1]), hvals.weights)
+end
+
+"""
+    TBVector(data)
+
+Forces `data` to be serialized as a vector in the histogram backend of
+TensorBoard.
+"""
+struct TBVector <: WrapperLogType data::AbstractArray; end
+content(x::TBVector) = x.data
+summary_impl(name, val::TBVector) = histogram_summary(name, collect(0:length(val.data)),
+                                                            val.data)

--- a/src/logger_dispatch_overrides.jl
+++ b/src/logger_dispatch_overrides.jl
@@ -34,6 +34,16 @@ struct TBText <: WrapperLogType data; end
 content(x::TBText) = x.data
 summary_impl(name, val::TBText) = text_summary(name, val.data)
 
+"""
+    RealArrayWrapperLogType{T,N} <: WrapperLogType
+
+A wrapper type that accepts only arrays and converts complex-valued arrays
+into two real value ones
+"""
+abstract type RealArrayWrapperLogType{T,N} <: WrapperLogType end
+
+preprocess(name, val::RealArrayWrapperLogType{T,N}, data) where {T<:Complex,N} =
+    push!(data, name*"/re"=>real.(content(val)), name*"/im"=>imag.(content(val)))
 
 ########## For things going to LogHistograms ########################
 """
@@ -41,7 +51,7 @@ summary_impl(name, val::TBText) = text_summary(name, val.data)
 
 Forces `data` to be serialized as an histogram to TensorBoard.
 """
-struct TBHistogram <: WrapperLogType data::AbstractArray; end
+struct TBHistogram{T,N} <: RealArrayWrapperLogType{T,N} data::AbstractArray{T,N}; end
 content(x::TBHistogram) = x.data
 function summary_impl(name, val::TBHistogram)
     hvals = fit(Histogram, val.data)
@@ -54,7 +64,7 @@ end
 Forces `data` to be serialized as a vector in the histogram backend of
 TensorBoard.
 """
-struct TBVector <: WrapperLogType data::AbstractArray; end
+struct TBVector{T,N} <: RealArrayWrapperLogType{T,N} data::AbstractArray{T,N}; end
 content(x::TBVector) = x.data
 summary_impl(name, val::TBVector) = histogram_summary(name, collect(0:length(val.data)),
                                                             val.data)

--- a/src/logger_dispatch_overrides.jl
+++ b/src/logger_dispatch_overrides.jl
@@ -42,9 +42,6 @@ into two real value ones
 """
 abstract type RealArrayWrapperLogType{T,N} <: WrapperLogType end
 
-preprocess(name, val::RealArrayWrapperLogType{T,N}, data) where {T<:Complex,N} =
-    push!(data, name*"/re"=>real.(content(val)), name*"/im"=>imag.(content(val)))
-
 ########## For things going to LogHistograms ########################
 """
     TBHistogram(data)
@@ -53,6 +50,8 @@ Forces `data` to be serialized as an histogram to TensorBoard.
 """
 struct TBHistogram{T,N} <: RealArrayWrapperLogType{T,N} data::AbstractArray{T,N}; end
 content(x::TBHistogram) = x.data
+preprocess(name, val::TBHistogram{T,N}, data) where {T<:Complex,N} =
+    push!(data, name*"/re"=>TBHistogram(real.(content(val))), name*"/im"=>TBHistogram(imag.(content(val))))
 function summary_impl(name, val::TBHistogram)
     hvals = fit(Histogram, val.data)
     return histogram_summary(name, collect(hvals.edges[1]), hvals.weights)
@@ -66,5 +65,7 @@ TensorBoard.
 """
 struct TBVector{T,N} <: RealArrayWrapperLogType{T,N} data::AbstractArray{T,N}; end
 content(x::TBVector) = x.data
+preprocess(name, val::TBVector{T,N}, data) where {T<:Complex,N} =
+    push!(data, name*"/re"=>TBVector(real.(content(val))), name*"/im"=>TBVector(imag.(content(val))))
 summary_impl(name, val::TBVector) = histogram_summary(name, collect(0:length(val.data)),
                                                             val.data)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -125,3 +125,7 @@ end
 
     @test TensorBoardLogger.step(logger) == 100
 end
+
+@testset "Logger dispatch overrides" begin
+    include("test_logger_dispatch_overrides.jl")
+end

--- a/test/test_logger_dispatch_overrides.jl
+++ b/test/test_logger_dispatch_overrides.jl
@@ -1,0 +1,34 @@
+using TensorBoardLogger, Test
+using TensorBoardLogger: preprocess, content
+
+@testset "TBText" begin
+    data = Vector{Pair{String,Any}}()
+    preprocess("test", TBText(Complex(1.0,3.0)), data)
+    @test first(data) == ("test"=>TBText(Complex(1.0,3.0)))
+end
+
+@testset "TBHistogram" begin
+    data = Vector{Pair{String,Any}}()
+    arr = rand(ComplexF64, 5)
+    preprocess("test", TBHistogram(arr), data)
+    @test !(first(data) == ("test"=>TBHistogram(arr)))
+    k,v = pop!(data)
+    @test k == "test/im"
+    @test content(v) == imag(arr) && typeof(v)<:TBHistogram
+    k,v = pop!(data)
+    @test k == "test/re"
+    @test v.data == real(arr) && typeof(v)<:TBHistogram
+end
+
+@testset "TBVector" begin
+    data = Vector{Pair{String,Any}}()
+    arr = rand(ComplexF64, 5)
+    preprocess("test", TBVector(arr), data)
+    @test !(first(data) == ("test"=>TBVector(arr)))
+    k,v = pop!(data)
+    @test k == "test/im"
+    @test content(v) == imag(arr) && typeof(v)<:TBVector
+    k,v = pop!(data)
+    @test k == "test/re"
+    @test v.data == real(arr) && typeof(v)<:TBVector
+end


### PR DESCRIPTION
Regardless of the discussion in #10, this is a first implementation of wrapper types. 

At the moment I only added `TBText`, `TBHistogram` and `TBVector`. This should all that we can support at the moment, until new loggers are added.

**cc** @oxinabox @shashikdm

