### PR TITLE
Add SummaryCollection constructors that take the summaries

### DIFF
--- a/src/Loggers/LogHistograms.jl
+++ b/src/Loggers/LogHistograms.jl
@@ -10,8 +10,7 @@ be used to bin the data.
 function log_histogram(logger::TBLogger, name::AbstractString, (bins,weights)::Tuple{AbstractVector, AbstractArray};
                        step=nothing)
     weights = collect(vec(weights))
-    summ    = SummaryCollection()
-    push!(summ.value,  histogram_summary(name, collect(bins), weights))
+    summ = SummaryCollection(histogram_summary(name, collect(bins), weights))
     write_event(logger.file, make_event(logger, summ, step=step))
 end
 
@@ -24,9 +23,8 @@ Bins the values found in `data` and logs them as an histogram under the tag
 function log_histogram(logger::TBLogger, name::AbstractString, data::AbstractArray;
                        step=nothing)
     data = vec(data)
-    summ    = SummaryCollection()
     hvals = fit(Histogram, data)
-    push!(summ.value, histogram_summary(name, collect(hvals.edges[1]), hvals.weights))
+    summ = SummaryCollection(histogram_summary(name, collect(hvals.edges[1]), hvals.weights))
     write_event(logger.file, make_event(logger, summ, step=step))
 end
 
@@ -36,8 +34,7 @@ end
 Logs the vector found in `data` as an histogram under the name `name`.
 """
 function log_vector(logger::TBLogger, name::AbstractString, data::AbstractVector; step=nothing)
-    summ    = SummaryCollection()
-    push!(summ.value, histogram_summary(name, collect(0:length(data)),data))
+    summ = SummaryCollection(histogram_summary(name, collect(0:length(data)),data))
     write_event(logger.file, make_event(logger, summ, step=step))
 end
 

--- a/src/Loggers/LogImage.jl
+++ b/src/Loggers/LogImage.jl
@@ -170,8 +170,7 @@ function log_image(logger::TBLogger, name::AbstractString, imgArray::AbstractArr
     end
     )
     imgArray = formatdict[format](imgArray)
-    summ = SummaryCollection()
-    push!(summ.value, image_summary(name, imgArray))
+    summ = SummaryCollection(image_summary(name, imgArray))
     write_event(logger.file, make_event(logger, summ, step=step))
 end
 

--- a/src/Loggers/LogText.jl
+++ b/src/Loggers/LogText.jl
@@ -5,8 +5,7 @@ Logs text with name `name` at step `step`
 - text: If text is a 2-D or 3-D `Array`, it will be rendered as a table or a list. Any other data will be represented as string
 """
 function log_text(logger::TBLogger, name::String, text::Any; step = nothing)
-    summ = SummaryCollection()
-    push!(summ.value, text_summary(name, text))
+    summ = SummaryCollection(text_summary(name, text))
     write_event(logger.file, make_event(logger, summ, step=step))
 end
 

--- a/src/Loggers/LogValue.jl
+++ b/src/Loggers/LogValue.jl
@@ -4,8 +4,7 @@
 Logs a Floating-point variable with name `name` at step `step`
 """
 function log_value(logger::TBLogger, name::AbstractString, value::Real; step=nothing)
-    summ    = SummaryCollection()
-    push!(summ.value, scalar_summary(name, value))
+    summ    = SummaryCollection(scalar_summary(name, value))
     write_event(logger.file, make_event(logger, summ, step=step))
 end
 

--- a/src/Loggers/LogValue.jl
+++ b/src/Loggers/LogValue.jl
@@ -4,7 +4,7 @@
 Logs a Floating-point variable with name `name` at step `step`
 """
 function log_value(logger::TBLogger, name::AbstractString, value::Real; step=nothing)
-    summ    = SummaryCollection(scalar_summary(name, value))
+    summ = SummaryCollection(scalar_summary(name, value))
     write_event(logger.file, make_event(logger, summ, step=step))
 end
 

--- a/src/event.jl
+++ b/src/event.jl
@@ -1,6 +1,8 @@
 # Create summary for Summary_value (default constructor by
 # protobuf is broken).
-const SummaryCollection(;kwargs...) = Summary(value=Base.Vector{Summary_Value}(); kwargs...)
+SummaryCollection(;kwargs...) = Summary(value=Vector{Summary_Value}(); kwargs...)
+SummaryCollection(summaries::Vector{Summary_Value}; kwargs...) = Summary(value=summaries; kwargs...)
+SummaryCollection(summary::Summary_Value; kwargs...) = Summary(value=[summary]; kwargs...)
 
 function make_event(logger::TBLogger, summary::Summary;
                     step::Int=TensorBoardLogger.step(logger))


### PR DESCRIPTION
This makes the code cleaner.
We could probably benefit from doing this to a few other protobuf constructor's too