### PR TITLE
Do not directly depend on ImageMagick

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -8,19 +8,19 @@ CRC32c = "8bf52ea8-c179-5cab-976a-9e18b702a9bc"
 ColorTypes = "3da002f7-5984-5a60-b8a6-cbb66c0b333f"
 FileIO = "5789e2e9-d7fb-5bc7-8068-2c6fae9b9549"
 ImageCore = "a09fc81d-aa75-5fe9-8630-4744c3626534"
-ImageMagick = "6218d12a-5da1-5696-b52f-db25d2ecc6d1"
 ProtoBuf = "3349acd9-ac6a-5e09-bcdb-63829b23a429"
 StatsBase = "2913bbd2-ae8a-5f71-8c99-4fb6c76f3a91"
 
 [compat]
-julia = "0.7, 1"
 ProtoBuf = ">= 0.7"
 StatsBase = ">= 0.27"
+julia = "0.7, 1"
 
 [extras]
 Flux = "587475ba-b771-5e3f-ad9e-33799f191a9c"
-TestImages = "5e47fb64-e119-507b-a336-dd2b206d9990"
+ImageMagick = "6218d12a-5da1-5696-b52f-db25d2ecc6d1"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
+TestImages = "5e47fb64-e119-507b-a336-dd2b206d9990"
 
 [targets]
-test = ["Test", "Flux", "TestImages"]
+test = ["Test", "Flux", "TestImages", "ImageMagick"]

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "TensorBoardLogger"
 uuid = "899adc3e-224a-11e9-021f-63837185c80f"
 authors = ["Filippo Vicentini <filippovicentini@gmail.com>"]
-version = "0.1.1"
+version = "0.1.2"
 
 [deps]
 CRC32c = "8bf52ea8-c179-5cab-976a-9e18b702a9bc"

--- a/README.md
+++ b/README.md
@@ -56,6 +56,7 @@ At the moment, we can serialize to the following TensorBoard backends (plugins):
   - *Scalar*        for real-valued data  (`log_value`)  
   - *Histograms*    for real-value histograms (`log_histogram` and `log_vector`)
   - *Text*          for markdown (`log_text`)
+  - *Image*         for images (`log_image`). Note: you will need either ImageMagick.jl or QuartzImageIO.jl installed in the current enviroment for Image logging to function.
 
 When you use the Logging interface we break down structures in order to obtain types that 
 can be serialized to one of those backends. In particoular, the behaviour is the following:

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -6,6 +6,7 @@ using TestImages
 using ImageCore
 using ColorTypes
 
+
 @testset "TBLogger" begin
     include("test_TBLogger.jl")
 end


### PR DESCRIPTION
ImageMagick is a rather heavy weight dependency.
Through the wizardry of FileIO.jl we don't need to directly depend on it.
We just need it installed, or else the `log_image` functions throw an error.
The error message is actually pretty helpful and clear anyway:

```
Errors encountered while saving nothing.
All errors:
   ArgumentError("Package QuartzImageIO not found in current path:\n- Run `import Pkg; Pkg.add(\"Qu
artzImageIO\")` to install the QuartzImageIO package.\n")
   ArgumentError("Package ImageMagick not found in current path:\n- Run `import Pkg; Pkg.add(\"ImageMagick\")` to install the ImageMagick package.\n")
```

People who do not use the `log_image` functions don't care,
and so this massively speeds up install/precompile time for them.
Which is good. Because I am one of them (right now)