### PR TITLE
Generic Log Image implementation

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "TensorBoardLogger"
 uuid = "899adc3e-224a-11e9-021f-63837185c80f"
 authors = ["Filippo Vicentini <filippovicentini@gmail.com>"]
-version = "0.1.3"
+version = "0.1.5"
 
 [deps]
 CRC32c = "8bf52ea8-c179-5cab-976a-9e18b702a9bc"

--- a/REQUIRE
+++ b/REQUIRE
@@ -1,2 +1,0 @@
-julia 1.1
-ProtoBuf

--- a/src/ImageFormat.jl
+++ b/src/ImageFormat.jl
@@ -1,6 +1,7 @@
 # Note: we use the 100s place of the enum to represent the number of dimensions
 # And the 10s place to represent which dimension is the observation (N), 0 for no observation dimension
 @enum ImageFormat begin
+    PNG=0;
     L=100;
     CL=200; LC; HW; WH; NL=210; LN=220;
     HWC=300; WHC; CHW; CWH; NCL=310; NHW; NWH; NLC; CLN=330; LCN; HWN; WHN;

--- a/src/ImageFormat.jl
+++ b/src/ImageFormat.jl
@@ -15,3 +15,18 @@ const strip_obs = Dict(
     NHW=>HW, HWN=>HW, NWH=>WH, WHN=>WH,
     NHWC=>HWC, NWHC=>WHC, NCHW=>CHW, NCWH=>CWH, HWCN=>HWC, WHCN=>WHC, CHWN=>CHW, CWHN=>CWH
 )
+
+function convert_to_CHW(imgArray::AbstractArray, format)
+    converted =
+        format == L   ? reshape(imgArray, (1, 1, size(imgArray, 1))) :
+        format == CL  ? reshape(imgArray, (size(imgArray, 1), 1, size(imgArray, 2))) :
+        format == LC  ? reshape(transpose(imgArray), (size(imgArray, 2), 1, size(imgArray, 1))) :
+        format == HW  ? reshape(imgArray, (1, size(imgArray, 1), size(imgArray, 2))) :
+        format == WH  ? reshape(transpose(imgArray), (1, size(imgArray, 2), size(imgArray, 1))) :
+        format == HWC ? permutedims(imgArray, (3, 1, 2)) :
+        format == WHC ? permutedims(imgArray, (3, 2, 1)) :
+        format == CHW ? imgArray :
+        format == CWH ? permutedims(imgArray, (1, 3, 2)) :
+        #== else ==# throw("Invalid format")
+    return converted
+end

--- a/src/ImageFormat.jl
+++ b/src/ImageFormat.jl
@@ -30,3 +30,13 @@ function convert_to_CHW(imgArray::AbstractArray, format)
         #== else ==# throw("Invalid format")
     return converted
 end
+
+function ColorType_from_nchannels(channels)
+    color =
+        channels == 1 ? Gray :
+        channels == 2 ? GrayA :
+        channels == 3 ? RGB :
+        channels == 4 ? RGBA :
+        #== else ==# throw("Too many channels")
+    return color
+end

--- a/src/Loggers/LogImage.jl
+++ b/src/Loggers/LogImage.jl
@@ -60,7 +60,7 @@ Renders the object to PNG and sends it to TensorBoard as an image with tag `name
 """
 function log_image(lg::TBLogger, name::AbstractString, obj; step=nothing)
     if !showable("image/png", obj)
-        @error "cannot log as an image object $obj"
+        @error "cannot log $name as an image object $obj"
         return
     end
     pb = PipeBuffer()

--- a/src/Loggers/LogImage.jl
+++ b/src/Loggers/LogImage.jl
@@ -1,4 +1,4 @@
-function image_summary(name::AbstractString, img::PNG)
+function image_summary(name::AbstractString, img::PngImage)
 
     attr    = img.attr
     imgsumm = Summary_Image(height     = attr[:height],
@@ -72,5 +72,5 @@ function log_image(lg::TBLogger, name::AbstractString, obj; step=nothing)
     end
     pb = PipeBuffer()
     show(pb, "image/png", obj)
-    log_keyval(lg, name, PNG(pb), step)
+    log_keyval(lg, name, PngImage(pb), step)
 end

--- a/src/Loggers/LogImage.jl
+++ b/src/Loggers/LogImage.jl
@@ -61,6 +61,7 @@ Renders the object to PNG and sends it to TensorBoard as an image with tag `name
 function log_image(lg::TBLogger, name::AbstractString, obj; step=nothing)
     if !showable("image/png", obj)
         @error "cannot log as an image object $obj"
+        return
     end
     pb = PipeBuffer()
     show(pb, "image/png", obj)

--- a/src/Loggers/LogImage.jl
+++ b/src/Loggers/LogImage.jl
@@ -21,9 +21,16 @@ Log multiple images using `Array` of images and format
    HWN, WHN, NHW, NWH,
    HWCN, WHCN, CHWN, CWHN, NHWC, NWHC, NCHW, NCWH}
 """
-function log_images(logger::TBLogger, name::AbstractString, imgArrays::AbstractArray; step = nothing)
-    @assert isa(first(imgArrays), AbstractArray{<:Colorant}) "Please specify format"
-    log_keyval(logger, name, imgArrays, step)
+function log_images(logger::TBLogger, name::AbstractString, img_array::AbstractArray; step = nothing)
+    if isa(first(img_array), AbstractArray{<:Colorant})
+        log_keyval(logger, name, img_array, step)
+    elseif showable("image/png", first(img_array))
+        for (i,img)=enumerate(img_array)
+            log_image(logger, name*"/$i", img, step=step)
+        end
+    else
+        @error "Array is neither <:AbstractArray{<:Colorant} nor showable to png.\n If it's numeric data, you should specify the format."
+    end
 end
 
 log_images(logger::TBLogger, name::AbstractString, imgArrays::AbstractArray, format::ImageFormat; step = nothing) =

--- a/src/Loggers/LogImage.jl
+++ b/src/Loggers/LogImage.jl
@@ -51,3 +51,18 @@ log_image(logger::TBLogger, name::AbstractString, img::AbstractArray{<:Colorant}
 
 log_image(logger::TBLogger, name::AbstractString, imgArray::AbstractArray, format::ImageFormat; step=nothing) =
     log_keyval(logger, name, TBImage(imgArray, format), step)
+
+"""
+log_image(logger, name, obj; [step=current_step])
+
+Renders the object to PNG and sends it to TensorBoard as an image with tag `name`.
+`showable("image/png", obj)` must be true.
+"""
+function log_image(lg::TBLogger, name::AbstractString, obj; step=nothing)
+    if !showable("image/png", obj)
+        @error "cannot log as an image object $obj"
+    end
+    pb = PipeBuffer()
+    show(pb, "image/png", obj)
+    log_keyval(lg, name, PNG(pb), step)
+end

--- a/src/Optional/Plots.jl
+++ b/src/Optional/Plots.jl
@@ -13,6 +13,3 @@ preprocess(name, plots::AbstractArray{<:Plots.Plot}, data) = begin
     end
     return data
 end
-
-log_image(lg::TBLogger, name::AbstractString, img::AbstractArray{<:Plots.Plot}; step=nothing) =
-    log_keyval(lg, name, img, step)

--- a/src/Optional/Plots.jl
+++ b/src/Optional/Plots.jl
@@ -14,14 +14,5 @@ preprocess(name, plots::AbstractArray{<:Plots.Plot}, data) = begin
     return data
 end
 
-
-"""
-    log_image(logger, name, plot::Plots.Plot; [step=current_step])
-
-Renders the Plots' and sends it to TensorBoard as an image with tag `name`.
-"""
-log_image(lg::TBLogger, name::AbstractString, img::Plots.Plot; step=nothing) =
-    log_keyval(lg, name, img, step)
-
 log_image(lg::TBLogger, name::AbstractString, img::AbstractArray{<:Plots.Plot}; step=nothing) =
     log_keyval(lg, name, img, step)

--- a/src/Optional/Plots.jl
+++ b/src/Optional/Plots.jl
@@ -1,12 +1,12 @@
 import .Plots: Plots
 
-function Base.convert(t::Type{PNG}, plot::Plots.Plot)
+function Base.convert(t::Type{PngImage}, plot::Plots.Plot)
     pb = PipeBuffer()
     show(pb, MIME("image/png"), plot)
-    return PNG(pb)
+    return PngImage(pb)
 end
 
-preprocess(name, plot::Plots.Plot, data) = preprocess(name, convert(PNG, plot), data)
+preprocess(name, plot::Plots.Plot, data) = preprocess(name, convert(PngImage, plot), data)
 preprocess(name, plots::AbstractArray{<:Plots.Plot}, data) = begin
     for (i, plot)=enumerate(plots)
         preprocess(name*"/$i", plot, data)

--- a/src/Optional/PyPlot.jl
+++ b/src/Optional/PyPlot.jl
@@ -14,13 +14,5 @@ preprocess(name, plots::AbstractArray{<:PyPlot.Figure}, data) = begin
     return data
 end
 
-"""
-    log_image(logger, name, plot::Plots.Figure; [step=current_step])
-
-Renders the PyPlots' and sends it to TensorBoard as an image with tag `name`.
-"""
-log_image(lg::TBLogger, name::AbstractString, img::PyPlot.Figure; step=nothing) =
-    log_keyval(lg, name, img, step)
-
 log_image(lg::TBLogger, name::AbstractString, img::AbstractArray{<:PyPlot.Figure}; step=nothing) =
     log_keyval(lg, name, img, step)

--- a/src/Optional/PyPlot.jl
+++ b/src/Optional/PyPlot.jl
@@ -13,6 +13,3 @@ preprocess(name, plots::AbstractArray{<:PyPlot.Figure}, data) = begin
     end
     return data
 end
-
-log_image(lg::TBLogger, name::AbstractString, img::AbstractArray{<:PyPlot.Figure}; step=nothing) =
-    log_keyval(lg, name, img, step)

--- a/src/Optional/PyPlot.jl
+++ b/src/Optional/PyPlot.jl
@@ -1,12 +1,12 @@
 import .PyPlot: PyPlot
 
-function Base.convert(t::Type{PNG}, figure::PyPlot.Figure)
+function Base.convert(t::Type{PngImage}, figure::PyPlot.Figure)
     pb = PipeBuffer()
     show(pb, MIME("image/png"), figure)
-    return PNG(pb)
+    return PngImage(pb)
 end
 
-preprocess(name, plot::PyPlot.Figure, data) = preprocess(name, convert(PNG, plot), data)
+preprocess(name, plot::PyPlot.Figure, data) = preprocess(name, convert(PngImage, plot), data)
 preprocess(name, plots::AbstractArray{<:PyPlot.Figure}, data) = begin
     for (i, plot)=enumerate(plots)
         preprocess(name*"/$i", plot, data)

--- a/src/PNG.jl
+++ b/src/PNG.jl
@@ -1,19 +1,19 @@
 # Official spec : http://www.libpng.org/pub/png/spec/1.2/png-1.2.pdf
 
 """
-    PNG
+    PngImage
 
 A wrapper around the binary encoding of a PNG image, holding it's attributes
 """
-struct PNG
+struct PngImage
     attr::Dict
     data::Vector{UInt8}
 end
 
-function PNG(buffer::Base.IOBuffer)
+function PngImage(buffer::Base.IOBuffer)
     !check_valid_png(buffer.data) && return false
     attr  = read_info(buffer.data)
-    return PNG(attr, buffer.data)
+    return PngImage(attr, buffer.data)
 end
 
 """
@@ -74,8 +74,8 @@ function read_info(data)
     return attr
 end
 
-function Base.convert(::Type{PNG}, img::AbstractArray{<:Colorant})
+function Base.convert(::Type{PngImage}, img::AbstractArray{<:Colorant})
     pb = PipeBuffer()
     save(Stream(format"PNG", pb), img)
-    return PNG(pb)
+    return PngImage(pb)
 end

--- a/src/TBLogger.jl
+++ b/src/TBLogger.jl
@@ -197,14 +197,15 @@ end
 
 # Implement the AbstractLogger Interface
 
-catch_exceptions(lg::TBLogger) = false
+CoreLogging.catch_exceptions(lg::TBLogger) = false
 
-min_enabled_level(lg::TBLogger) = lg.min_level
+CoreLogging.min_enabled_level(lg::TBLogger) = lg.min_level
 
 # For now, log everything that is above the lg.min_level
-shouldlog(lg::TBLogger, level, _module, group, id) = true
+CoreLogging.shouldlog(lg::TBLogger, level, _module, group, id) = true
 
-function handle_message(lg::TBLogger, level, message, _module, group, id, file, line; kwargs...)
+function CoreLogging.handle_message(lg::TBLogger, level, message, _module, group,
+									id, file, line; kwargs...)
     # Unpack the message
     summ    = SummaryCollection()
     i_step = 1 # :log_step_increment default value

--- a/src/TensorBoardLogger.jl
+++ b/src/TensorBoardLogger.jl
@@ -6,11 +6,9 @@ using ImageCore, ColorTypes
 using FileIO: @format_str, Stream, save
 
 using StatsBase  #TODO: remove this. Only needed to compute histogram bins.
-using Base.CoreLogging: global_logger, LogLevel, Info
-import Base.CoreLogging:
-    AbstractLogger, handle_message, shouldlog, min_enabled_level,
-    catch_exceptions
 
+using  Base.CoreLogging: CoreLogging, AbstractLogger, LogLevel, Info,
+    handle_message, shouldlog, min_enabled_level, catch_exceptions
 
 export TBLogger, reset!, set_step!, increment_step!
 export log_histogram, log_value, log_vector, log_text, log_image, log_images,

--- a/src/TensorBoardLogger.jl
+++ b/src/TensorBoardLogger.jl
@@ -1,21 +1,23 @@
 module TensorBoardLogger
-using ProtoBuf
-using CRC32c
-using ImageCore
-using ColorTypes
-using FileIO
-using FileIO: @format_str
+
+using ProtoBuf, CRC32c
+
+using ImageCore, ColorTypes
+using FileIO: @format_str, Stream, save
+
 using StatsBase  #TODO: remove this. Only needed to compute histogram bins.
 using Base.CoreLogging: global_logger, LogLevel, Info
 import Base.CoreLogging:
     AbstractLogger, handle_message, shouldlog, min_enabled_level,
     catch_exceptions
 
-export log_histogram, log_value, log_vector, log_text, log_image, log_images, log_audio, log_audios, log_graph
-export scalar_summary, histogram_summary, text_summary, make_event
-export TBLogger
-export reset!, set_step!, increment_step!
-export ImageFormat, L, CL, LC, LN, NL, NCL, NLC, CLN, LCN, HW, WH, HWC, WHC, CHW, CWH,HWN, WHN, NHW, NWH, HWCN, WHCN, CHWN, CWHN, NHWC, NWHC, NCHW, NCWH
+
+export TBLogger, reset!, set_step!, increment_step!
+export log_histogram, log_value, log_vector, log_text, log_image, log_images,
+       log_audio, log_audios, log_graph
+export ImageFormat, L, CL, LC, LN, NL, NCL, NLC, CLN, LCN, HW, WH, HWC, WHC,
+       CHW, CWH,HWN, WHN, NHW, NWH, HWCN, WHCN, CHWN, CWHN, NHWC, NWHC, NCHW, NCWH
+
 # Wrapper types
 export TBText, TBVector, TBHistogram, TBImage, TBImages, TBAudio, TBAudios
 

--- a/src/logger_dispatch.jl
+++ b/src/logger_dispatch.jl
@@ -49,15 +49,15 @@ function preprocess(name,   img::AbstractArray{<:Colorant}, data)
         #3rd is channel dim as observed in testimages
         channels = size(img, 3)
         for c in 1:channels
-            preprocess(name, convert(PNG, img[:, :, c]), data)
+            preprocess(name, convert(PngImage, img[:, :, c]), data)
         end
     else
-        preprocess(name, convert(PNG, img), data)
+        preprocess(name, convert(PngImage, img), data)
     end
     return data
 end
-preprocess(name, val::PNG, data) = push!(data, name=>val)
-summary_impl(name, value::PNG) = image_summary(name, value)
+preprocess(name, val::PngImage, data) = push!(data, name=>val)
+summary_impl(name, value::PngImage) = image_summary(name, value)
 
 
 ########## For things going to LogText ##############################

--- a/src/logger_dispatch_overrides.jl
+++ b/src/logger_dispatch_overrides.jl
@@ -156,18 +156,12 @@ function preprocess(name, val::TBImage, data)
         preprocess(name, convert(PngImage, val), data)
     else
         imgArray = channelview(imgArray)
-        dims = ndims(imgArray)
-        @assert dims == expected_ndims(format)
+        @assert ndims(imgArray) == expected_ndims(format)
 
         format = strip_obs[format]
-        index = collect("[:"* ",:"^(dims-1) *"]")
-        index[2*obsdim] = 'g'
-        index = join(index)
-        global gimgArray = imgArray
-        nth_img = Meta.parse("gimgArray$(index)")
         for n in 1:size(imgArray, obsdim)
-            global g = n
-            preprocess(name*"/$n", convert(PngImage, TBImage(eval(nth_img), format)), data)
+            nth_img = selectdim(imgArray, obsdim, n)
+            preprocess(name*"/$n", convert(PngImage, TBImage(nth_img, format)), data)
         end
     end
     return data

--- a/src/logger_dispatch_overrides.jl
+++ b/src/logger_dispatch_overrides.jl
@@ -109,7 +109,7 @@ function Base.convert(T::Type{PngImage}, img::TBImage)
         show(pb, "image/png", img.data)
         return PngImage(pb)
     else
-        @error "Unknown format $(img.format) for data of type $(typeof(img.data))."
+        @error "Unknown format for datatype." format=img.format datatype=typeof(img.data) 
         return nothing
     end
 end

--- a/src/logger_dispatch_overrides.jl
+++ b/src/logger_dispatch_overrides.jl
@@ -124,22 +124,12 @@ function Base.convert(T::Type{PngImage}, img::TBImage{<:AbstractArray})
     if isa(first(imgArray), Integer)
         imgArray = (imgArray./255)
     end
-    #convert all values to `Float64` for uniformity
+
+    #convert all values to `Float64` for uniformity and scale all values to 0-1
     imgArray = Float64.(imgArray)
-    #scale all values to 0-1
     imgArray = (imgArray./(max(maximum(imgArray), 1)))
-    #convert any format to CHW
-    imgArray =
-        format == L   ? reshape(imgArray, (1, 1, size(imgArray, 1))) :
-        format == CL  ? reshape(imgArray, (size(imgArray, 1), 1, size(imgArray, 2))) :
-        format == LC  ? reshape(transpose(imgArray), (size(imgArray, 2), 1, size(imgArray, 1))) :
-        format == HW  ? reshape(imgArray, (1, size(imgArray, 1), size(imgArray, 2))) :
-        format == WH  ? reshape(transpose(imgArray), (1, size(imgArray, 2), size(imgArray, 1))) :
-        format == HWC ? permutedims(imgArray, (3, 1, 2)) :
-        format == WHC ? permutedims(imgArray, (3, 2, 1)) :
-        format == CHW ? imgArray :
-        format == CWH ? permutedims(imgArray, (1, 3, 2)) :
-        #== else ==# throw("Invalid format")
+    imgArray = convert_to_CHW(imgArray, format)
+
     channels, height, width = size(imgArray)
     color =
         channels == 1 ? Gray :

--- a/src/logger_dispatch_overrides.jl
+++ b/src/logger_dispatch_overrides.jl
@@ -155,13 +155,16 @@ end
 function preprocess(name, val::TBImage, data)
     imgArray = val.data
     format = val.format
-    imgArray = channelview(imgArray)
-    dims = ndims(imgArray)
-    @assert dims == expected_ndims(format)
     obsdim = obs_dim(format)
+
+    # obs_dim of PNG format is 0
     if iszero(obsdim)
         preprocess(name, convert(PngImage, val), data)
     else
+        imgArray = channelview(imgArray)
+        dims = ndims(imgArray)
+        @assert dims == expected_ndims(format)
+
         format = strip_obs[format]
         index = collect("[:"* ",:"^(dims-1) *"]")
         index[2*obsdim] = 'g'

--- a/src/logger_dispatch_overrides.jl
+++ b/src/logger_dispatch_overrides.jl
@@ -131,12 +131,8 @@ function Base.convert(T::Type{PngImage}, img::TBImage{<:AbstractArray})
     imgArray = convert_to_CHW(imgArray, format)
 
     channels, height, width = size(imgArray)
-    color =
-        channels == 1 ? Gray :
-        channels == 2 ? GrayA :
-        channels == 3 ? RGB :
-        channels == 4 ? RGBA :
-        #== else ==# throw("Too many channels")
+    color = ColorType_from_nchannels(channels)
+
     #if it is a single channel Array, convert it to HW
     if color == Gray
         imgArray = imgArray[1, :, :]

--- a/src/logger_dispatch_overrides.jl
+++ b/src/logger_dispatch_overrides.jl
@@ -102,7 +102,7 @@ content(x::TBImage) = x.data
 function Base.convert(T::Type{PngImage}, img::TBImage)
     if img.format == PNG
         if !showable("image/png", img.data)
-            @error "cannot log as an image object $obj"
+            @error "cannot log as an image object" obj=img.data
             return
         end
         pb=PipeBuffer()

--- a/test/Optional/test_Plots.jl
+++ b/test/Optional/test_Plots.jl
@@ -18,7 +18,7 @@ show(pb, MIME("image/png"), p)
 data = TensorBoardLogger.preprocess("key", p, Vector())
 @test length(data) == 1
 @test first(data[1]) == "key"
-@test last(data[1]) isa TensorBoardLogger.PNG
+@test last(data[1]) isa TensorBoardLogger.PngImage
 @test last(data[1]).data == pb.data
 
 # test unpacking of array of plots
@@ -26,6 +26,6 @@ data = TensorBoardLogger.preprocess("key", [p, p], Vector())
 @test length(data) == 2
 @test first(data[1]) == "key/1"
 @test first(data[2]) == "key/2"
-@test last(data[1]) isa TensorBoardLogger.PNG
-@test last(data[2]) isa TensorBoardLogger.PNG
+@test last(data[1]) isa TensorBoardLogger.PngImage
+@test last(data[2]) isa TensorBoardLogger.PngImage
 end

--- a/test/Optional/test_PyPlot.jl
+++ b/test/Optional/test_PyPlot.jl
@@ -20,7 +20,7 @@ show(pb, MIME("image/png"), p)
 data = TensorBoardLogger.preprocess("key", p, Vector())
 @test length(data) == 1
 @test first(data[1]) == "key"
-@test last(data[1]) isa TensorBoardLogger.PNG
+@test last(data[1]) isa TensorBoardLogger.PngImage
 @test last(data[1]).data == pb.data
 
 # test unpacking of array of plots
@@ -28,6 +28,6 @@ data = TensorBoardLogger.preprocess("key", [p, p], Vector())
 @test length(data) == 2
 @test first(data[1]) == "key/1"
 @test first(data[2]) == "key/2"
-@test last(data[1]) isa TensorBoardLogger.PNG
-@test last(data[2]) isa TensorBoardLogger.PNG
+@test last(data[1]) isa TensorBoardLogger.PngImage
+@test last(data[2]) isa TensorBoardLogger.PngImage
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -117,51 +117,55 @@ end
     logger = TBLogger("test_logs/t", tb_overwrite)
     step = 1
 
-    #testing number Arrays
-    log_image(logger, "rand/auto", colorview(Gray, rand(10)), step = step)
-    log_image(logger, "rand/L", rand(10), L, step = step)
-    log_image(logger, "rand/LN", rand(10, 3) ,LN, step = step)
-    log_image(logger, "rand/NL", rand(3, 10), NL, step = step)
-    log_image(logger, "rand/CL", rand(3, 10), CL, step = step)
-    log_image(logger, "rand/LC", rand(10, 3), LC, step = step)
-    log_image(logger, "rand/NCL", rand(2, 3, 10), NCL, step = step)
-    log_image(logger, "rand/NLC", rand(2, 10, 3), NLC, step = step)
-    log_image(logger, "rand/CLN", rand(3, 10, 2), CLN, step = step)
-    log_image(logger, "rand/LCN", rand(10, 3, 2), LCN, step = step)
+    # The following tests are akin to @test_nothrow, which does not exist.
+    # https://github.com/JuliaLang/julia/issues/18780
+
+    # testing number Arrays
+    @test π != log_image(logger, "rand/auto", colorview(Gray, rand(10)), step = step)
+    @test π != log_image(logger, "rand/L", rand(10), L, step = step)
+    @test π != log_image(logger, "rand/LN", rand(10, 3) ,LN, step = step)
+    @test π != log_image(logger, "rand/NL", rand(3, 10), NL, step = step)
+    @test π != log_image(logger, "rand/CL", rand(3, 10), CL, step = step)
+    @test π != log_image(logger, "rand/LC", rand(10, 3), LC, step = step)
+    @test π != log_image(logger, "rand/NCL", rand(2, 3, 10), NCL, step = step)
+    @test π != log_image(logger, "rand/NLC", rand(2, 10, 3), NLC, step = step)
+    @test π != log_image(logger, "rand/CLN", rand(3, 10, 2), CLN, step = step)
+    @test π != log_image(logger, "rand/LCN", rand(10, 3, 2), LCN, step = step)
 
     sample = MNIST.images()[1:3]
     sample = hcat(sample...)
     sample = reshape(sample, (28, 28, 3))
-    log_image(logger, "mnist/HWN", sample, HWN, step = step)
+    @test  π != log_image(logger, "mnist/HWN", sample, HWN, step = step)
     sample = permutedims(sample, (2, 1, 3))
-    log_image(logger, "mnist/WHN", sample, WHN, step = step)
+    @test  π != log_image(logger, "mnist/WHN", sample, WHN, step = step)
     sample = permutedims(sample, (3, 2, 1))
-    log_image(logger, "mnist/NHW", sample, NHW, step = step)
+    @test  π != log_image(logger, "mnist/NHW", sample, NHW, step = step)
     sample = permutedims(sample, (1, 3, 2))
-    log_image(logger, "mnist/NWH", sample, NWH, step = step)
+    @test  π != log_image(logger, "mnist/NWH", sample, NWH, step = step)
     sample = testimage("toucan")
-    log_image(logger, "toucan/auto", sample, step = step)
+    @test  π != log_image(logger, "toucan/auto", sample, step = step)
     sample = [sample, sample, sample]
-    log_images(logger, "toucans/auto", sample, step = step)
-    log_images(logger, "toucans", sample, CHW, step = step)
+    @test  π != log_images(logger, "toucans/auto", sample, step = step)
+    @test  π != log_images(logger, "toucans", sample, CHW, step = step)
+
     sample = hcat(sample...)
     sample = reshape(sample, (150, 162, 3))
-    log_image(logger, "toucan/CHWN", sample, CHWN, step = step)
+    @test  π != log_image(logger, "toucan/CHWN", sample, CHWN, step = step)
     sample = permutedims(sample, (2, 1, 3))
-    log_image(logger, "toucan/CWHN", sample, CWHN, step = step)
+    @test  π != log_image(logger, "toucan/CWHN", sample, CWHN, step = step)
     sample = channelview(sample) #CWHN
     sample = permutedims(sample, (4, 1, 2, 3))
-    log_image(logger, "toucan/NCWH", sample, NCWH, step = step)
+    @test  π != log_image(logger, "toucan/NCWH", sample, NCWH, step = step)
     sample = permutedims(sample, (1, 2, 4, 3))
-    log_image(logger, "toucan/NCHW", sample, NCHW, step = step)
+    @test  π != log_image(logger, "toucan/NCHW", sample, NCHW, step = step)
     sample = permutedims(sample, (1, 4, 3, 2))
-    log_image(logger, "toucan/NWHC", sample, NWHC, step = step)
+    @test  π != log_image(logger, "toucan/NWHC", sample, NWHC, step = step)
     sample = permutedims(sample, (1, 3, 2, 4))
-    log_image(logger, "toucan/NHWC", sample, NHWC, step = step)
+    @test  π != log_image(logger, "toucan/NHWC", sample, NHWC, step = step)
     sample = permutedims(sample, (2, 3, 4, 1))
-    log_image(logger, "toucan/HWCN", sample, HWCN, step = step)
+    @test  π != log_image(logger, "toucan/HWCN", sample, HWCN, step = step)
     sample = permutedims(sample, (2, 1, 3, 4))
-    log_image(logger, "toucan/WHCN", sample, WHCN, step = step)
+    @test  π != log_image(logger, "toucan/WHCN", sample, WHCN, step = step)
 
 end
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -171,7 +171,7 @@ end
     lighthouse = testimage("lighthouse")
     @test data == preprocess("test1", lighthouse, data)
     @test first(data[1])=="test1"
-    @test last(data[1]) isa TensorBoardLogger.PNG
+    @test last(data[1]) isa TensorBoardLogger.PngImage
     #3-d MRI image
     data = Vector{Pair{String,Any}}()
     mri = testimage("mri-stack")
@@ -184,10 +184,10 @@ end
         isok = false
     end
     @test isok
-    # check that all slices have been converted to PNG
+    # check that all slices have been converted to PngImage
     isok = true
     for (tag,val)=data
-        val isa TensorBoardLogger.PNG && continue
+        val isa TensorBoardLogger.PngImage && continue
         isok = false
     end
     @test isok


### PR DESCRIPTION
Fixes #49 

Adds a generic `log_image` that checks if type can be rendered to png and does that if possible.

I just need to think about how to handle arrays of plots (do we even need to? this seems to create a lot of redundant methods...