### PR TITLE
Support StatsBase.Histogram

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "TensorBoardLogger"
 uuid = "899adc3e-224a-11e9-021f-63837185c80f"
 authors = ["Filippo Vicentini <filippovicentini@gmail.com>"]
-version = "0.1.6"
+version = "0.1.7"
 
 [deps]
 CRC32c = "8bf52ea8-c179-5cab-976a-9e18b702a9bc"

--- a/src/Loggers/LogHistograms.jl
+++ b/src/Loggers/LogHistograms.jl
@@ -40,10 +40,15 @@ end
 
 function histogram_summary(name::AbstractString, edges::AbstractVector{<:Number}, hist_vals::AbstractVector{<:Number})
     @assert length(edges) == length(hist_vals)+1
+    return histogram_summary(name, Histogram(edges, hist_vals))
+end
 
+function histogram_summary(name::AbstractString, hist::StatsBase.Histogram{T,1}) where T
+    edges     = first(hist.edges)
+    hist_vals = hist.weights
 
-    hp = HistogramProto(min=minimum(edges), max=maximum(edges),
-                        bucket_limit=edges[2:end],
+    hp = HistogramProto(min=first(edges), max=last(edges),
+                        bucket_limit=collect(edges[2:end]),
                         bucket=hist_vals)
     return Summary_Value(tag=name, histo=hp)
 end

--- a/src/logger_dispatch_overrides.jl
+++ b/src/logger_dispatch_overrides.jl
@@ -193,10 +193,7 @@ end
 content(x::TBHistogram) = x.data
 preprocess(name, val::TBHistogram{T,N}, data) where {T<:Complex,N} =
     push!(data, name*"/re"=>TBHistogram(real.(content(val))), name*"/im"=>TBHistogram(imag.(content(val))))
-function summary_impl(name, val::TBHistogram)
-    hvals = fit(Histogram, val.data)
-    return histogram_summary(name, collect(hvals.edges[1]), hvals.weights)
-end
+preprocess(name, val::TBHistogram, data) = preprocess(data, fit(Histogram, val.data), data)
 
 """
     TBVector(data)


### PR DESCRIPTION
Also changes slightly the internals.
Instead of internally propagating histograms in `preprocess` as `Tuple(Vector, Vector)`, which does not necessarily indicate an histogram, we use internally StatsBase.Histogram.

To be backward compatible, we convert `Tuple{Vector,Vector}` to Histograms, but this should eventually be removed in a future, backward incompatible release.