### PR TITLE
Remove ImageMagick bug workaround

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -15,7 +15,7 @@ StatsBase = "2913bbd2-ae8a-5f71-8c99-4fb6c76f3a91"
 
 [compat]
 ColorTypes = "0.7, 0.8, 0.9, 0.10"
-FileIO = "1"
+FileIO = "1.2.3"
 FixedPointNumbers = "0.6, 0.7, 0.8"
 ImageCore = "0.7, 0.8, 0.9"
 ProtoBuf = "0.10, 0.11"
@@ -24,6 +24,7 @@ StatsBase = "0.27, 0.28, 0.29, 0.30, 0.31, 0.32, 0.33"
 julia = "1.3"
 
 [extras]
+ImageIO = "82e4d734-157c-48bb-816b-45c225c6df19"
 ImageMagick = "6218d12a-5da1-5696-b52f-db25d2ecc6d1"
 LightGraphs = "093fc24a-ae57-5d10-9952-331d41423f4d"
 Logging = "56ddb016-857b-54e1-b83d-db4d58db5568"
@@ -38,4 +39,4 @@ ValueHistories = "98cad3c8-aec3-5f06-8e41-884608649ab7"
 WAV = "8149f6b0-98f6-5db9-b78f-408fbbb8ef88"
 
 [targets]
-test = ["Test", "MLDatasets", "TestImages", "ImageMagick", "Logging", "LightGraphs", "Plots", "PyPlot", "WAV", "Tracker", "ValueHistories", "QuartzImageIO"]
+test = ["Test", "MLDatasets", "TestImages", "ImageMagick", "Logging", "LightGraphs", "Plots", "PyPlot", "WAV", "Tracker", "ValueHistories", "QuartzImageIO", "ImageIO"]

--- a/src/Deserialization/audio.jl
+++ b/src/Deserialization/audio.jl
@@ -2,7 +2,7 @@ function deserialize_audio_summary(summary)
     audio = summary.audio
 
     if audio.content_type == "audio/wav"
-        value = load(Stream(format"WAV", PipeBuffer(audio.encoded_audio_string)))
+        value = load(Stream{format"WAV"}(PipeBuffer(audio.encoded_audio_string)))
     else
         value = nothing
         @warn "unknown audio format $(audio.content_type)"

--- a/src/Deserialization/audio.jl
+++ b/src/Deserialization/audio.jl
@@ -2,7 +2,7 @@ function deserialize_audio_summary(summary)
     audio = summary.audio
 
     if audio.content_type == "audio/wav"
-        value = load(Stream{format"WAV"}(PipeBuffer(audio.encoded_audio_string)))
+        value = load(_format_stream(format"WAV", PipeBuffer(audio.encoded_audio_string)))
     else
         value = nothing
         @warn "unknown audio format $(audio.content_type)"

--- a/src/Deserialization/images.jl
+++ b/src/Deserialization/images.jl
@@ -1,7 +1,7 @@
 function deserialize_image_summary(summary)
     img = summary.image
 
-    value = load(Stream(format"PNG", IOBuffer(img.encoded_image_string)))
+    value = load(_format_stream(format"PNG", IOBuffer(img.encoded_image_string)))
 
     return value
 end

--- a/src/FileIO_workaround.jl
+++ b/src/FileIO_workaround.jl
@@ -1,0 +1,10 @@
+using FileIO: FileIO
+
+# Required for compatibility with pre 1.6 and post 1.6
+# drop in the future if the minimum requirement is bumped
+if isdefined(FileIO, :action)
+    # FileIO >= 1.6
+    _format_stream(format, io) = FileIO.Stream{format}(io)
+else
+    _format_stream(format, io) = FileIO.Stream(format, io)
+end

--- a/src/Loggers/LogAudio.jl
+++ b/src/Loggers/LogAudio.jl
@@ -30,7 +30,7 @@ function audio_summary(name::AbstractString, samples::AbstractArray, samplerate:
     samples = samples./max(maximum(samples), 1)
     samples = Int16.(floor.(samples.*32767))
     io = IOBuffer()
-    save(Stream{format"WAV"}(io), samples)
+    save(_format_stream(format"WAV",io), samples)
     eas = io.data
     audio = Summary_Audio(sample_rate = samplerate, num_channels = ndims(samples), length_frames = size(samples, 1), encoded_audio_string = eas, content_type = "audio/wav")
     Summary_Value(tag=name, audio=audio)

--- a/src/Loggers/LogAudio.jl
+++ b/src/Loggers/LogAudio.jl
@@ -30,7 +30,7 @@ function audio_summary(name::AbstractString, samples::AbstractArray, samplerate:
     samples = samples./max(maximum(samples), 1)
     samples = Int16.(floor.(samples.*32767))
     io = IOBuffer()
-    save(Stream(format"WAV", io), samples)
+    save(Stream{format"WAV"}(io), samples)
     eas = io.data
     audio = Summary_Audio(sample_rate = samplerate, num_channels = ndims(samples), length_frames = size(samples, 1), encoded_audio_string = eas, content_type = "audio/wav")
     Summary_Value(tag=name, audio=audio)

--- a/src/PNG.jl
+++ b/src/PNG.jl
@@ -7,6 +7,9 @@ using FixedPointNumbers: Normed
 
 export PngImage, png_color_T
 
+# workaround for FileIO pre 1.6
+include("FileIO_workaround.jl")
+
 """
     PngImage
 
@@ -83,7 +86,7 @@ end
 
 function Base.convert(::Type{PngImage}, img::AbstractArray{<:Colorant})
     pb = PipeBuffer()
-    save(Stream{format"PNG"}(pb), img)
+    save(_format_stream(format"PNG", pb), img)
     return PngImage(pb)
 end
 

--- a/src/TensorBoardLogger.jl
+++ b/src/TensorBoardLogger.jl
@@ -32,6 +32,9 @@ export tb_multiline, tb_margin
 # Wrapper types
 export TBText, TBVector, TBHistogram, TBImage, TBImages, TBAudio, TBAudios
 
+# workaround for FileIO pre 1.6
+include("FileIO_workaround.jl")
+
 # Protobuffer definitions for tensorboard
 include("protojl/tensorboard/tensorboard.jl")
 using .tensorboard: Summary_Value, GraphDef, Summary, Event, SessionLog_SessionStatus, SessionLog

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -13,292 +13,296 @@ ENV["GKSwstype"] = "100"
 
 ENV["DATADEPS_ALWAYS_ACCEPT"] = true
 
-@testset "TBLogger" begin
-    include("test_TBLogger.jl")
-end
+@testset "TensorBoardLogger" begin
 
-@testset "Scalar Value Logger" begin
-    logger = TBLogger(test_log_dir*"t", tb_overwrite)
-    step = 1
-
-    ss = TensorBoardLogger.scalar_summary("test", 12.0)
-    @test isa(ss, TensorBoardLogger.Summary_Value)
-    @test ss.simple_value == 12.0
-    @test ss.tag == "test"
-
-    log_value(logger, "float32", 1.25f0, step=step)
-    log_value(logger, "float64", 1.5, step=step)
-    log_value(logger, "irr", pi, step=step)
-    log_value(logger, "complex", 1.0 + 1.0im, step=step)
-    
-    close.(values(logger.all_files))
-end
-
-@testset "Scalar Value processing interface" begin
-    data = Vector{Pair{String,Any}}()
-    @test data == preprocess("test1", 1.0, data)
-    @test first(data[1])=="test1"
-    @test last(data[1])==1.0
-
-    data == preprocess("test2", 1.0+0.5im, data)
-    @test first(data[2])=="test2/re"
-    @test last(data[2])==1.0
-    @test first(data[3])=="test2/im"
-    @test last(data[3])==0.5
-end
-
-@testset "Histogram Value Logger" begin
-    logger = TBLogger(test_log_dir*"t", tb_overwrite)
-    step = 1
-
-    x0 = 0.5+step/30; s0 = 0.5/(step/20);
-    edges = collect(-5:0.1:5)
-    centers = collect(edges[1:end-1] .+0.05)
-    histvals = [exp(-((c-x0)/s0)^2) for c=centers]
-    data_tuple = (edges, histvals)
-
-    ss = TensorBoardLogger.histogram_summary("test", edges, histvals)
-    @test isa(ss, TensorBoardLogger.Summary_Value)
-    @test ss.tag == "test"
-    @test isa(ss.histo, TensorBoardLogger.HistogramProto)
-    @test ss.histo.min == minimum(edges)
-    @test ss.histo.max == maximum(edges)
-    @test all(ss.histo.bucket_limit.== edges[2:end])
-    @test all(ss.histo.bucket.== histvals)
-
-    log_histogram(logger, "hist/cust", data_tuple, step=step)
-    log_histogram(logger, "hist/cust", rand(100), step=step)
-    log_histogram(logger, "hist/cust", rand(10,10), step=step)
-    log_vector(logger, "hist/cust", rand(10), step=step)
-
-    close.(values(logger.all_files))
-end
-
-@testset "Histogram processing interface" begin
-    data = Vector{Pair{String,Any}}()
-    vals = rand(10)
-    @test data == preprocess("test1", vals, data)
-    @test first(data[1]) == "test1"
-    @test last(data[1])  == vals
-
-    vals = rand(ComplexF32, 10)
-    preprocess("test2", vals, data)
-    @test first(data[2]) == "test2/re"
-    @test last(data[2])  == real.(vals)
-    @test first(data[3]) == "test2/im"
-    @test last(data[3])  == imag.(vals)
-
-    vals = rand(10, 10)
-    preprocess("test2", vals, data)
-    @test last(data[4]) == vals
-
-end
-
-@testset "Text Logger" begin
-    logger = TBLogger(test_log_dir*"t", tb_overwrite)
-    step = 1
-
-    ss = TensorBoardLogger.text_summary("test", "Hello World")
-    @test isa(ss, TensorBoardLogger.Summary_Value)
-    @test ss.tag == "test"
-
-    log_text(logger, "phrase", "Hello World", step = step)
-    log_text(logger, "sentence", "A quick brown fox jumped over a lazy dog.\n", step = step)
-    log_text(logger, "multilines", "Is this the real life?\nIs this just fantacy?", step = step)
-    log_text(logger, "markdown", "**This** is the *power*  of >>>markdown", step = step)
-    log_text(logger, "html", "<p> HTML is a programming language</p>", step = step)
-    log_text(logger, "docstring", """This should work too""", step = step)
-    log_text(logger, "Array", collect(1:10), step = step)
-    log_text(logger, "Matrix", rand(4, 4), step = step)
-
-    close.(values(logger.all_files))
-end
-
-@testset "Text processing interface" begin
-    data = Vector{Pair{String,Any}}()
-    @test data == preprocess("test1", "helloworld", data)
-    @test first(data[1])=="test1"
-    @test last(data[1])=="helloworld"
-
-    data == preprocess("test2", """helloworld""", data)
-    @test first(data[2])=="test2"
-    @test last(data[2])=="""helloworld"""
-end
-
-@testset "Image Logger" begin
-    logger = TBLogger(test_log_dir*"t", tb_overwrite)
-    step = 1
-
-    # The following tests are akin to @test_nothrow, which does not exist.
-    # https://github.com/JuliaLang/julia/issues/18780
-
-    # testing number Arrays
-    @test π != log_image(logger, "rand/auto", colorview(Gray, rand(10)), step = step)
-    @test π != log_image(logger, "rand/L", rand(10), L, step = step)
-    @test π != log_image(logger, "rand/LN", rand(10, 3) ,LN, step = step)
-    @test π != log_image(logger, "rand/NL", rand(3, 10), NL, step = step)
-    @test π != log_image(logger, "rand/CL", rand(3, 10), CL, step = step)
-    @test π != log_image(logger, "rand/LC", rand(10, 3), LC, step = step)
-    @test π != log_image(logger, "rand/NCL", rand(2, 3, 10), NCL, step = step)
-    @test π != log_image(logger, "rand/NLC", rand(2, 10, 3), NLC, step = step)
-    @test π != log_image(logger, "rand/CLN", rand(3, 10, 2), CLN, step = step)
-    @test π != log_image(logger, "rand/LCN", rand(10, 3, 2), LCN, step = step)
-
-    if VERSION >= v"1.3.0"
-        using MLDatasets: MNIST 
-
-        sample = MNIST.traintensor(1:3)
-        @test  π != log_image(logger, "mnist/HWN", sample, HWN, step = step)
-        @test  π != log_image(logger, "mnist2/HWN", Gray.(sample), step = step)
-        sample = permutedims(sample, (2, 1, 3))
-        @test  π != log_image(logger, "mnist/WHN", sample, WHN, step = step)
-        @test  π != log_image(logger, "mnist2/WHN", Gray.(sample), WHN, step = step)
-        sample = permutedims(sample, (3, 2, 1))
-        @test  π != log_image(logger, "mnist/NHW", sample, NHW, step = step)
-        @test  π != log_image(logger, "mnist2/NHW", Gray.(sample), NHW, step = step)
-        sample = permutedims(sample, (1, 3, 2))
-        @test  π != log_image(logger, "mnist/NWH", sample, NWH, step = step)
-        @test  π != log_image(logger, "mnist2/NWH", Gray.(sample), NWH, step = step)
-        sample = testimage("toucan")
-        @test  π != log_image(logger, "toucan/auto", sample, step = step)
-        sample = [sample, sample, sample]
-        @test  π != log_images(logger, "toucans/auto", sample, step = step)
-        @test  π != log_images(logger, "toucans", sample, CHW, step = step)
-
-        sample = hcat(sample...)
-        sample = reshape(sample, (150, 162, 3))
-        @test  π != log_image(logger, "toucan/CHWN", sample, CHWN, step = step)
-        sample = permutedims(sample, (2, 1, 3))
-        @test  π != log_image(logger, "toucan/CWHN", sample, CWHN, step = step)
-        sample = channelview(sample) #CWHN
-        sample = permutedims(sample, (4, 1, 2, 3))
-        @test  π != log_image(logger, "toucan/NCWH", sample, NCWH, step = step)
-        sample = permutedims(sample, (1, 2, 4, 3))
-        @test  π != log_image(logger, "toucan/NCHW", sample, NCHW, step = step)
-        sample = permutedims(sample, (1, 4, 3, 2))
-        @test  π != log_image(logger, "toucan/NWHC", sample, NWHC, step = step)
-        sample = permutedims(sample, (1, 3, 2, 4))
-        @test  π != log_image(logger, "toucan/NHWC", sample, NHWC, step = step)
-        sample = permutedims(sample, (2, 3, 4, 1))
-        @test  π != log_image(logger, "toucan/HWCN", sample, HWCN, step = step)
-        sample = permutedims(sample, (2, 1, 3, 4))
-        @test  π != log_image(logger, "toucan/WHCN", sample, WHCN, step = step)
+    @testset "TBLogger" begin
+        include("test_TBLogger.jl")
     end
-    close.(values(logger.all_files))
-end
 
-@testset "Image processing interface" begin
-    #2-d image
-    data = Vector{Pair{String,Any}}()
-    lighthouse = testimage("lighthouse")
-    @test data == preprocess("test1", lighthouse, data)
-    @test first(data[1])=="test1"
-    @test last(data[1]) isa TensorBoardLogger.PngImage
-    #3-d MRI image
-    data = Vector{Pair{String,Any}}()
-    mri = testimage("mri-stack")
-    @test data == preprocess("test2", mri, data)
-    @test length(data) == size(mri, 3)
-    # check that all slices have been logged with same tag
-    isok = true
-    for (tag,val)=data
-        tag == "test2" && continue
-        isok = false
-    end
-    @test isok
-    # check that all slices have been converted to PngImage
-    isok = true
-    for (tag,val)=data
-        val isa TensorBoardLogger.PngImage && continue
-        isok = false
-    end
-    @test isok
-end
+    @testset "Scalar Value Logger" begin
+        logger = TBLogger(test_log_dir*"t", tb_overwrite)
+        step = 1
 
-@testset "LogInterface" begin
-    logger = TBLogger(test_log_dir*"t", tb_overwrite)
-    woman = testimage("woman_blonde")
-    mri = testimage("mri")
-    with_logger(logger) do
-        for i=1:5
-            x0 = 0.5+i/30; s0 = 0.5/(i/20);
-            edges = collect(-5:0.1:5)
-            centers = collect(edges[1:end-1] .+0.05)
-            histvals = [exp(-((c-x0)/s0)^2) for c=centers]
-            data_tuple = (edges, histvals)
-            @info "test1" simpletext = "simple text" woman = woman mriimg = mri
-            @info "test2" i=i j=i^2 dd=rand(10).+0.1*i hh=data_tuple
-            @info "test3" i=i j=2^i dd=rand(10).-0.1*i hh=data_tuple log_step_increment=0
+        ss = TensorBoardLogger.scalar_summary("test", 12.0)
+        @test isa(ss, TensorBoardLogger.Summary_Value)
+        @test ss.simple_value == 12.0
+        @test ss.tag == "test"
+
+        log_value(logger, "float32", 1.25f0, step=step)
+        log_value(logger, "float64", 1.5, step=step)
+        log_value(logger, "irr", pi, step=step)
+        log_value(logger, "complex", 1.0 + 1.0im, step=step)
+        
+        close.(values(logger.all_files))
+    end
+
+    @testset "Scalar Value processing interface" begin
+        data = Vector{Pair{String,Any}}()
+        @test data == preprocess("test1", 1.0, data)
+        @test first(data[1])=="test1"
+        @test last(data[1])==1.0
+
+        data == preprocess("test2", 1.0+0.5im, data)
+        @test first(data[2])=="test2/re"
+        @test last(data[2])==1.0
+        @test first(data[3])=="test2/im"
+        @test last(data[3])==0.5
+    end
+
+    @testset "Histogram Value Logger" begin
+        logger = TBLogger(test_log_dir*"t", tb_overwrite)
+        step = 1
+
+        x0 = 0.5+step/30; s0 = 0.5/(step/20);
+        edges = collect(-5:0.1:5)
+        centers = collect(edges[1:end-1] .+0.05)
+        histvals = [exp(-((c-x0)/s0)^2) for c=centers]
+        data_tuple = (edges, histvals)
+
+        ss = TensorBoardLogger.histogram_summary("test", edges, histvals)
+        @test isa(ss, TensorBoardLogger.Summary_Value)
+        @test ss.tag == "test"
+        @test isa(ss.histo, TensorBoardLogger.HistogramProto)
+        @test ss.histo.min == minimum(edges)
+        @test ss.histo.max == maximum(edges)
+        @test all(ss.histo.bucket_limit.== edges[2:end])
+        @test all(ss.histo.bucket.== histvals)
+
+        log_histogram(logger, "hist/cust", data_tuple, step=step)
+        log_histogram(logger, "hist/cust", rand(100), step=step)
+        log_histogram(logger, "hist/cust", rand(10,10), step=step)
+        log_vector(logger, "hist/cust", rand(10), step=step)
+
+        close.(values(logger.all_files))
+    end
+
+    @testset "Histogram processing interface" begin
+        data = Vector{Pair{String,Any}}()
+        vals = rand(10)
+        @test data == preprocess("test1", vals, data)
+        @test first(data[1]) == "test1"
+        @test last(data[1])  == vals
+
+        vals = rand(ComplexF32, 10)
+        preprocess("test2", vals, data)
+        @test first(data[2]) == "test2/re"
+        @test last(data[2])  == real.(vals)
+        @test first(data[3]) == "test2/im"
+        @test last(data[3])  == imag.(vals)
+
+        vals = rand(10, 10)
+        preprocess("test2", vals, data)
+        @test last(data[4]) == vals
+
+    end
+
+    @testset "Text Logger" begin
+        logger = TBLogger(test_log_dir*"t", tb_overwrite)
+        step = 1
+
+        ss = TensorBoardLogger.text_summary("test", "Hello World")
+        @test isa(ss, TensorBoardLogger.Summary_Value)
+        @test ss.tag == "test"
+
+        log_text(logger, "phrase", "Hello World", step = step)
+        log_text(logger, "sentence", "A quick brown fox jumped over a lazy dog.\n", step = step)
+        log_text(logger, "multilines", "Is this the real life?\nIs this just fantacy?", step = step)
+        log_text(logger, "markdown", "**This** is the *power*  of >>>markdown", step = step)
+        log_text(logger, "html", "<p> HTML is a programming language</p>", step = step)
+        log_text(logger, "docstring", """This should work too""", step = step)
+        log_text(logger, "Array", collect(1:10), step = step)
+        log_text(logger, "Matrix", rand(4, 4), step = step)
+
+        close.(values(logger.all_files))
+    end
+
+    @testset "Text processing interface" begin
+        data = Vector{Pair{String,Any}}()
+        @test data == preprocess("test1", "helloworld", data)
+        @test first(data[1])=="test1"
+        @test last(data[1])=="helloworld"
+
+        data == preprocess("test2", """helloworld""", data)
+        @test first(data[2])=="test2"
+        @test last(data[2])=="""helloworld"""
+    end
+
+    @testset "Image Logger" begin
+        logger = TBLogger(test_log_dir*"t", tb_overwrite)
+        step = 1
+
+        # The following tests are akin to @test_nothrow, which does not exist.
+        # https://github.com/JuliaLang/julia/issues/18780
+
+        # testing number Arrays
+        @test π != log_image(logger, "rand/auto", colorview(Gray, rand(10)), step = step)
+        @test π != log_image(logger, "rand/L", rand(10), L, step = step)
+        @test π != log_image(logger, "rand/LN", rand(10, 3) ,LN, step = step)
+        @test π != log_image(logger, "rand/NL", rand(3, 10), NL, step = step)
+        @test π != log_image(logger, "rand/CL", rand(3, 10), CL, step = step)
+        @test π != log_image(logger, "rand/LC", rand(10, 3), LC, step = step)
+        @test π != log_image(logger, "rand/NCL", rand(2, 3, 10), NCL, step = step)
+        @test π != log_image(logger, "rand/NLC", rand(2, 10, 3), NLC, step = step)
+        @test π != log_image(logger, "rand/CLN", rand(3, 10, 2), CLN, step = step)
+        @test π != log_image(logger, "rand/LCN", rand(10, 3, 2), LCN, step = step)
+
+        if VERSION >= v"1.3.0"
+            using MLDatasets: MNIST 
+
+            sample = MNIST.traintensor(1:3)
+            @test  π != log_image(logger, "mnist/HWN", sample, HWN, step = step)
+            @test  π != log_image(logger, "mnist2/HWN", Gray.(sample), step = step)
+            sample = permutedims(sample, (2, 1, 3))
+            @test  π != log_image(logger, "mnist/WHN", sample, WHN, step = step)
+            @test  π != log_image(logger, "mnist2/WHN", Gray.(sample), WHN, step = step)
+            sample = permutedims(sample, (3, 2, 1))
+            @test  π != log_image(logger, "mnist/NHW", sample, NHW, step = step)
+            @test  π != log_image(logger, "mnist2/NHW", Gray.(sample), NHW, step = step)
+            sample = permutedims(sample, (1, 3, 2))
+            @test  π != log_image(logger, "mnist/NWH", sample, NWH, step = step)
+            @test  π != log_image(logger, "mnist2/NWH", Gray.(sample), NWH, step = step)
+            sample = testimage("toucan")
+            @test  π != log_image(logger, "toucan/auto", sample, step = step)
+            sample = [sample, sample, sample]
+            @test  π != log_images(logger, "toucans/auto", sample, step = step)
+            @test  π != log_images(logger, "toucans", sample, CHW, step = step)
+
+            sample = hcat(sample...)
+            sample = reshape(sample, (150, 162, 3))
+            @test  π != log_image(logger, "toucan/CHWN", sample, CHWN, step = step)
+            sample = permutedims(sample, (2, 1, 3))
+            @test  π != log_image(logger, "toucan/CWHN", sample, CWHN, step = step)
+            sample = channelview(sample) #CWHN
+            sample = permutedims(sample, (4, 1, 2, 3))
+            @test  π != log_image(logger, "toucan/NCWH", sample, NCWH, step = step)
+            sample = permutedims(sample, (1, 2, 4, 3))
+            @test  π != log_image(logger, "toucan/NCHW", sample, NCHW, step = step)
+            sample = permutedims(sample, (1, 4, 3, 2))
+            @test  π != log_image(logger, "toucan/NWHC", sample, NWHC, step = step)
+            sample = permutedims(sample, (1, 3, 2, 4))
+            @test  π != log_image(logger, "toucan/NHWC", sample, NHWC, step = step)
+            sample = permutedims(sample, (2, 3, 4, 1))
+            @test  π != log_image(logger, "toucan/HWCN", sample, HWCN, step = step)
+            sample = permutedims(sample, (2, 1, 3, 4))
+            @test  π != log_image(logger, "toucan/WHCN", sample, WHCN, step = step)
+        end
+        close.(values(logger.all_files))
+    end
+
+    @testset "Image processing interface" begin
+        #2-d image
+        data = Vector{Pair{String,Any}}()
+        lighthouse = testimage("lighthouse")
+        @test data == preprocess("test1", lighthouse, data)
+        @test first(data[1])=="test1"
+        @test last(data[1]) isa TensorBoardLogger.PngImage
+        #3-d MRI image
+        data = Vector{Pair{String,Any}}()
+        mri = testimage("mri-stack")
+        @test data == preprocess("test2", mri, data)
+        @test length(data) == size(mri, 3)
+        # check that all slices have been logged with same tag
+        isok = true
+        for (tag,val)=data
+            tag == "test2" && continue
+            isok = false
+        end
+        @test isok
+        # check that all slices have been converted to PngImage
+        isok = true
+        for (tag,val)=data
+            val isa TensorBoardLogger.PngImage && continue
+            isok = false
+        end
+        @test isok
+    end
+
+    @testset "LogInterface" begin
+        logger = TBLogger(test_log_dir*"t", tb_overwrite)
+        woman = testimage("woman_blonde")
+        mri = testimage("mri")
+        with_logger(logger) do
+            for i=1:5
+                x0 = 0.5+i/30; s0 = 0.5/(i/20);
+                edges = collect(-5:0.1:5)
+                centers = collect(edges[1:end-1] .+0.05)
+                histvals = [exp(-((c-x0)/s0)^2) for c=centers]
+                data_tuple = (edges, histvals)
+                @info "test1" simpletext = "simple text" woman = woman mriimg = mri
+                @info "test2" i=i j=i^2 dd=rand(10).+0.1*i hh=data_tuple
+                @info "test3" i=i j=2^i dd=rand(10).-0.1*i hh=data_tuple log_step_increment=0
+            end
+        end
+        @test TensorBoardLogger.step(logger) == 10
+
+        close.(values(logger.all_files))
+    end
+
+    @testset "Audio Logger" begin
+        logger = TBLogger(test_log_dir*"t", tb_overwrite)
+        step = 1
+
+        ss = TensorBoardLogger.audio_summary("test", rand(800), 800)
+        @test isa(ss, TensorBoardLogger.Summary_Value)
+        @test ss.tag == "test"
+
+        clip = (cos.(440*pi*collect(1:100)/44100), 44100)
+        fs = clip[2]
+        sample = clip[1]
+        samples = [sample, sample, sample]
+        log_audios(logger, "audiosample", samples, fs, step = step)
+
+        close.(values(logger.all_files))
+    end
+
+    @testset "Graph Logger" begin
+        logger = TBLogger(test_log_dir*"t", tb_overwrite)
+        step = 1
+        ss = TensorBoardLogger.graph_summary(DiGraph(1), ["1"], ["1"], ["cpu"], [nothing])
+        @test isa(ss, TensorBoardLogger.GraphDef)
+        g = DiGraph(7)
+        add_edge!(g, 1, 2)
+        add_edge!(g, 2, 3)
+        add_edge!(g, 3, 6)
+        add_edge!(g, 4, 6)
+        add_edge!(g, 5, 6)
+        add_edge!(g, 5, 7)
+        log_graph(logger, g, step = step, nodedevice = ["cpu", "cpu", "gpu", "gpu", "gpu", "gpu", "cpu"], nodevalue = [1, "tf", 3.14, [1.0 2.0; 3.0 4.0], true, +, (10, "julia", 12.4)])
+
+        close.(values(logger.all_files))
+    end
+
+    @testset "Embedding Logger" begin
+        logger = TBLogger(test_log_dir*"t", tb_overwrite)
+        step = 1
+        mat = rand(4, 4)
+        metadata = rand(4, 10)
+        metadata_header = Array(collect(1:10))
+        imgs = TBImages(rand(8, 8, 3, 4), HWCN)
+        @test π != log_embeddings(logger, "random1", mat, metadata = metadata, metadata_header = metadata_header, img_labels = imgs, step = step)
+        @test π != log_embeddings(logger, "random2", mat, step = step+1)
+
+        close.(values(logger.all_files))
+    end
+
+    @testset "Logger dispatch overrides" begin
+        include("test_logger_dispatch_overrides.jl")
+    end
+
+    @testset "Optional dependency tests" begin
+        include("Optional/test_Plots.jl")
+        # Don't run PyPlot tests until I figure a way to install the dependencies
+        #include("Optional/test_PyPlot.jl")
+        if VERSION >= v"1.5.0"
+            include("Optional/test_Tracker.jl")
         end
     end
-    @test TensorBoardLogger.step(logger) == 10
 
-    close.(values(logger.all_files))
-end
-
-@testset "Audio Logger" begin
-    logger = TBLogger(test_log_dir*"t", tb_overwrite)
-    step = 1
-
-    ss = TensorBoardLogger.audio_summary("test", rand(800), 800)
-    @test isa(ss, TensorBoardLogger.Summary_Value)
-    @test ss.tag == "test"
-
-    clip = (cos.(440*pi*collect(1:100)/44100), 44100)
-    fs = clip[2]
-    sample = clip[1]
-    samples = [sample, sample, sample]
-    log_audios(logger, "audiosample", samples, fs, step = step)
-
-    close.(values(logger.all_files))
-end
-
-@testset "Graph Logger" begin
-    logger = TBLogger(test_log_dir*"t", tb_overwrite)
-    step = 1
-    ss = TensorBoardLogger.graph_summary(DiGraph(1), ["1"], ["1"], ["cpu"], [nothing])
-    @test isa(ss, TensorBoardLogger.GraphDef)
-    g = DiGraph(7)
-    add_edge!(g, 1, 2)
-    add_edge!(g, 2, 3)
-    add_edge!(g, 3, 6)
-    add_edge!(g, 4, 6)
-    add_edge!(g, 5, 6)
-    add_edge!(g, 5, 7)
-    log_graph(logger, g, step = step, nodedevice = ["cpu", "cpu", "gpu", "gpu", "gpu", "gpu", "cpu"], nodevalue = [1, "tf", 3.14, [1.0 2.0; 3.0 4.0], true, +, (10, "julia", 12.4)])
-
-    close.(values(logger.all_files))
-end
-
-@testset "Embedding Logger" begin
-    logger = TBLogger(test_log_dir*"t", tb_overwrite)
-    step = 1
-    mat = rand(4, 4)
-    metadata = rand(4, 10)
-    metadata_header = Array(collect(1:10))
-    imgs = TBImages(rand(8, 8, 3, 4), HWCN)
-    @test π != log_embeddings(logger, "random1", mat, metadata = metadata, metadata_header = metadata_header, img_labels = imgs, step = step)
-    @test π != log_embeddings(logger, "random2", mat, step = step+1)
-
-    close.(values(logger.all_files))
-end
-
-@testset "Logger dispatch overrides" begin
-    include("test_logger_dispatch_overrides.jl")
-end
-
-@testset "Optional dependency tests" begin
-    include("Optional/test_Plots.jl")
-    # Don't run PyPlot tests until I figure a way to install the dependencies
-    #include("Optional/test_PyPlot.jl")
-    if VERSION >= v"1.5.0"
-        include("Optional/test_Tracker.jl")
+    @testset "Logger deserialization" begin
+        include("deserialization.jl")
     end
-end
 
-@testset "Logger deserialization" begin
-    include("deserialization.jl")
-end
+    #cleanup
+    rm(test_log_dir, force=true, recursive=true)
 
-#cleanup
-rm(test_log_dir, force=true, recursive=true)
+end


### PR DESCRIPTION
Thanks to [ImageMagick#180](https://github.com/JuliaIO/ImageMagick.jl/pull/180) I can remove the ugly hack I had in place around for loading pngs from an in-memory stream.

This is fixed on ImageMagick v1.1.4. Which is an indirect dependency loaded by FileIO when needed on Linux (not on MacOs).  
However, I am unsure on how to properly set dependency bounds in this case.

Maybe we should carry the hack around for a bit longer?

cc @Arkoniak and @timholy who might have an idea about how to do this properly.
