### PR TITLE
Ignore non-event files in deserialized folder

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "TensorBoardLogger"
 uuid = "899adc3e-224a-11e9-021f-63837185c80f"
 authors = ["Filippo Vicentini <filippovicentini@gmail.com>"]
-version = "0.1.13"
+version = "0.1.14"
 
 [deps]
 CRC32c = "8bf52ea8-c179-5cab-976a-9e18b702a9bc"

--- a/src/Deserialization/deserialization.jl
+++ b/src/Deserialization/deserialization.jl
@@ -14,7 +14,7 @@ function is_valid_event(f::IOStream)
     length(header) != 8 && return false
 
     crc_header = read(f, 4)
-    length(header) != 4 && return false
+    length(crc_header) != 4 && return false
 
     # check
     crc_header_ck = reinterpret(UInt8, UInt32[masked_crc32c(header)])

--- a/test/deserialization.jl
+++ b/test/deserialization.jl
@@ -17,6 +17,12 @@ ENV["GKSwstype"] = "100"
         end
     end
 
+    # Issue #88: ignore non -tensorboard files
+    dir = TensorBoardLogger.logdir(logger)
+    f = open(joinpath(dir, "mockdata"), "w")
+    write(f, "baddta")
+    close(f)
+    
     tgs = TensorBoardLogger.tags(logger)
     @test "test/val" ∈ tgs
     @test "test/b" ∈ tgs
@@ -29,4 +35,5 @@ ENV["GKSwstype"] = "100"
     @test all(hist["test/val"].values .== (1-0.5*im).* is)
     @test all(hist["test/b"].values == is .* 2)
     @test all([v == mri for v=hist["test2/mri"].values])
+
 end


### PR DESCRIPTION
Alternative to #88 .
I don't want silent failures when deserialising, and if data is corrupt we should not keep going forward.

This fixes the issue described there, as it will check that all files are valid, first.   

needs a test