### PR TITLE
simplify the dependency managemant

### DIFF
--- a/.github/workflows/CompatHelper.yml
+++ b/.github/workflows/CompatHelper.yml
@@ -10,7 +10,7 @@ jobs:
     steps:
       - uses: julia-actions/setup-julia@latest
         with:
-          version: 1.6
+          version: 1.3
       - name: Pkg.add("CompatHelper")
         run: julia -e 'using Pkg; Pkg.add("CompatHelper")'
       - name: CompatHelper.main()

--- a/.github/workflows/UnitTest.yml
+++ b/.github/workflows/UnitTest.yml
@@ -42,5 +42,15 @@ jobs:
           ${{ runner.os }}-test-
           ${{ runner.os }}-
 
+    - name: "Compat fix for Julia == v1.3.0"
+      if: ${{ matrix.julia_version == '1.3' }}
+      run: |
+        using Pkg
+        Pkg.add([
+          PackageSpec(name="Reexport", version="0.2"),
+          PackageSpec(name="Plots", version="1.6"),
+        ])
+      shell: julia --project=. --startup=no --color=yes {0}
+
     - uses: julia-actions/julia-runtest@latest
 

--- a/.github/workflows/UnitTest.yml
+++ b/.github/workflows/UnitTest.yml
@@ -13,7 +13,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [macos-latest, ubuntu-latest]
-        julia_version: ["1.4", "1", "nightly"]
+        julia_version: ["1.3", "1", "nightly"]
 
     runs-on: ${{ matrix.os }}
     env:

--- a/Project.toml
+++ b/Project.toml
@@ -5,19 +5,15 @@ version = "0.1.16"
 
 [deps]
 CRC32c = "8bf52ea8-c179-5cab-976a-9e18b702a9bc"
-ColorTypes = "3da002f7-5984-5a60-b8a6-cbb66c0b333f"
 FileIO = "5789e2e9-d7fb-5bc7-8068-2c6fae9b9549"
-FixedPointNumbers = "53c48c17-4a7d-5ca2-90c5-79b7896eea93"
 ImageCore = "a09fc81d-aa75-5fe9-8630-4744c3626534"
 ProtoBuf = "3349acd9-ac6a-5e09-bcdb-63829b23a429"
 Requires = "ae029012-a4dd-5104-9daa-d747884805df"
 StatsBase = "2913bbd2-ae8a-5f71-8c99-4fb6c76f3a91"
 
 [compat]
-ColorTypes = "0.7, 0.8, 0.9, 0.10"
 FileIO = "1.2.3"
-FixedPointNumbers = "0.6, 0.7, 0.8"
-ImageCore = "0.7, 0.8, 0.9"
+ImageCore = "0.8.1, 0.9"
 ProtoBuf = "0.10, 0.11"
 Requires = "0.5, 1"
 StatsBase = "0.27, 0.28, 0.29, 0.30, 0.31, 0.32, 0.33"

--- a/Project.toml
+++ b/Project.toml
@@ -24,14 +24,12 @@ StatsBase = "0.27, 0.28, 0.29, 0.30, 0.31, 0.32, 0.33"
 julia = "1.3"
 
 [extras]
-ImageIO = "82e4d734-157c-48bb-816b-45c225c6df19"
 ImageMagick = "6218d12a-5da1-5696-b52f-db25d2ecc6d1"
 LightGraphs = "093fc24a-ae57-5d10-9952-331d41423f4d"
 Logging = "56ddb016-857b-54e1-b83d-db4d58db5568"
 MLDatasets = "eb30cadb-4394-5ae3-aed4-317e484a6458"
 Plots = "91a5bcdd-55d7-5caf-9e0b-520d859cae80"
 PyPlot = "d330b81b-6aea-500a-939a-2ce795aea3ee"
-QuartzImageIO = "dca85d43-d64c-5e67-8c65-017450d5d020"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 TestImages = "5e47fb64-e119-507b-a336-dd2b206d9990"
 Tracker = "9f7883ad-71c0-57eb-9f7f-b5c9e6d3789c"
@@ -39,4 +37,4 @@ ValueHistories = "98cad3c8-aec3-5f06-8e41-884608649ab7"
 WAV = "8149f6b0-98f6-5db9-b78f-408fbbb8ef88"
 
 [targets]
-test = ["Test", "MLDatasets", "TestImages", "ImageMagick", "Logging", "LightGraphs", "Plots", "PyPlot", "WAV", "Tracker", "ValueHistories", "QuartzImageIO", "ImageIO"]
+test = ["Test", "MLDatasets", "TestImages", "ImageMagick", "Logging", "LightGraphs", "Plots", "PyPlot", "WAV", "Tracker", "ValueHistories"]

--- a/src/PNG.jl
+++ b/src/PNG.jl
@@ -2,8 +2,7 @@
 module PNGImage
 
 using FileIO: @format_str, Stream, save
-using ColorTypes: Colorant, Gray, GrayA, RGB, RGBA
-using FixedPointNumbers: Normed
+using ImageCore: Colorant, Gray, GrayA, RGB, RGBA, Normed
 
 export PngImage, png_color_T
 

--- a/src/TensorBoardLogger.jl
+++ b/src/TensorBoardLogger.jl
@@ -4,7 +4,7 @@ using ProtoBuf: readproto, writeproto, ProtoType
 using CRC32c
 
 using ImageCore: colorview, channelview
-using ColorTypes: Colorant, Gray, GrayA, RGB, RGBA
+using ImageCore: Colorant, Gray, GrayA, RGB, RGBA
 using FileIO: FileIO, @format_str, Stream, save, load
 
 # hasproperty is not defined before 1.2. This is Compat.hasproperty

--- a/test/deserialization.jl
+++ b/test/deserialization.jl
@@ -9,11 +9,11 @@ ENV["GKSwstype"] = "100"
 @testset "Deserialization_simple" begin
     logger = TBLogger(test_log_dir*"d", tb_overwrite)
 
-    #mri = testimage("mri")
+    mri = testimage("mri")
     with_logger(logger) do
         for i=1:5
             @info "test" val=i-0.5*i*im b=i*2 mat=i.*ones(3) mat2=10 .*i.*ones(3,2)
-    #        @info "test2" mri
+            @info "test2" mri
         end
     end
 
@@ -28,13 +28,13 @@ ENV["GKSwstype"] = "100"
     @test "test/b" ∈ tgs
     @test "test/mat" ∈ tgs
     @test "test/mat2" ∈ tgs
-    #@test "test2/mri" ∈ tgs
+    @test "test2/mri" ∈ tgs
 
     hist = convert(MVHistory, logger)
     is = collect(1:5)
     @test all(hist["test/val"].values .== (1-0.5*im).* is)
     @test all(hist["test/b"].values == is .* 2)
-    #@test all([v == mri for v=hist["test2/mri"].values])
+    @test all([v == mri for v=hist["test2/mri"].values])
 
     close.(values(logger.all_files))
 end
@@ -42,11 +42,11 @@ end
 @testset "TBReader" begin
     logger = TBLogger(test_log_dir*"d", tb_overwrite)
 
-    #mri = testimage("mri")
+    mri = testimage("mri")
     with_logger(logger) do
         for i=1:5
             @info "test" val=i-0.5*i*im b=i*2 mat=i.*ones(3) mat2=10 .*i.*ones(3,2)
-    #        @info "test2" mri
+            @info "test2" mri
         end
     end
 
@@ -65,12 +65,12 @@ end
     @test "test/b" ∈ tgs
     @test "test/mat" ∈ tgs
     @test "test/mat2" ∈ tgs
-    #@test "test2/mri" ∈ tgs
+    @test "test2/mri" ∈ tgs
 
     hist = convert(MVHistory, reader)
     is = collect(1:5)
     @test all(hist["test/val"].values .== (1-0.5*im).* is)
     @test all(hist["test/b"].values == is .* 2)
-    #@test all([v == mri for v=hist["test2/mri"].values])
+    @test all([v == mri for v=hist["test2/mri"].values])
     
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -3,7 +3,6 @@ using TensorBoardLogger: preprocess, summary_impl
 using Test
 using TestImages
 using ImageCore
-using ColorTypes
 using FileIO
 using LightGraphs
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -198,29 +198,29 @@ ENV["DATADEPS_ALWAYS_ACCEPT"] = true
         @test last(data[1]) isa TensorBoardLogger.PngImage
         #3-d MRI image
         data = Vector{Pair{String,Any}}()
-        #mri = testimage("mri-stack")
-        #@test data == preprocess("test2", mri, data)
-        #@test length(data) == size(mri, 3)
-        ## check that all slices have been logged with same tag
-        #isok = true
-        #for (tag,val)=data
-        #    tag == "test2" && continue
-        #    isok = false
-        #end
-        #@test isok
-        ## check that all slices have been converted to PngImage
-        #isok = true
-        #for (tag,val)=data
-        #    val isa TensorBoardLogger.PngImage && continue
-        #    isok = false
-        #end
-        #@test isok
+        mri = testimage("mri-stack")
+        @test data == preprocess("test2", mri, data)
+        @test length(data) == size(mri, 3)
+        # check that all slices have been logged with same tag
+        isok = true
+        for (tag,val)=data
+            tag == "test2" && continue
+            isok = false
+        end
+        @test isok
+        # check that all slices have been converted to PngImage
+        isok = true
+        for (tag,val)=data
+            val isa TensorBoardLogger.PngImage && continue
+            isok = false
+        end
+        @test isok
     end
 
     @testset "LogInterface" begin
         logger = TBLogger(test_log_dir*"t", tb_overwrite)
         woman = testimage("woman_blonde")
-        #mri = testimage("mri")
+        mri = testimage("mri")
         with_logger(logger) do
             for i=1:5
                 x0 = 0.5+i/30; s0 = 0.5/(i/20);
@@ -228,12 +228,12 @@ ENV["DATADEPS_ALWAYS_ACCEPT"] = true
                 centers = collect(edges[1:end-1] .+0.05)
                 histvals = [exp(-((c-x0)/s0)^2) for c=centers]
                 data_tuple = (edges, histvals)
-                #@info "test1" simpletext = "simple text" woman = woman mriimg = mri
+                @info "test1" simpletext = "simple text" woman = woman mriimg = mri
                 @info "test2" i=i j=i^2 dd=rand(10).+0.1*i hh=data_tuple
                 @info "test3" i=i j=2^i dd=rand(10).-0.1*i hh=data_tuple log_step_increment=0
             end
         end
-        @test TensorBoardLogger.step(logger) == 5
+        @test TensorBoardLogger.step(logger) == 10
 
         close.(values(logger.all_files))
     end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -289,7 +289,11 @@ ENV["DATADEPS_ALWAYS_ACCEPT"] = true
     end
 
     @testset "Optional dependency tests" begin
-        include("Optional/test_Plots.jl")
+        if VERSION >= v"1.4.0"
+            # Plots v1.6, which is the last version compatible to Julia v1.3 is somehow buggy
+            # "UndefVarError: HDF5Group not defined"
+            include("Optional/test_Plots.jl")
+        end
         # Don't run PyPlot tests until I figure a way to install the dependencies
         #include("Optional/test_PyPlot.jl")
         if VERSION >= v"1.5.0"


### PR DESCRIPTION
- ImageCore v0.8.1 reexports Colors, ColorTypes and FixedPointNumbers
- ImageCore v0.9 loads ColorVectorSpaces
- ImageMagick is still the most comprehensive image io backend (although ImageIO is faster and lighter) so we can just use this one for the test purposes

On the reverts:

- The 1.3 issue is because QuartzImageIO isn't compatible to ImageCore 0.9 (https://github.com/JuliaIO/QuartzImageIO.jl/pull/70)
- The TestImages issue is because ImageIO uses TiffImages to load the tif image, which returns a unexpected `DenseTaggedImage` array type and breaks the code (https://github.com/JuliaImages/TestImages.jl/pull/113)

