### PR TITLE
Supress logging within `writeproto` to prevent infinite recursion.

### DIFF
--- a/src/TensorBoardLogger.jl
+++ b/src/TensorBoardLogger.jl
@@ -16,7 +16,8 @@ end
 using StatsBase: Histogram, fit
 
 using  Base.CoreLogging: CoreLogging, AbstractLogger, LogLevel, Info,
-    handle_message, shouldlog, min_enabled_level, catch_exceptions
+    handle_message, shouldlog, min_enabled_level, catch_exceptions, with_logger,
+    NullLogger
 
 export TBLogger, reset!, set_step!, increment_step!, set_step_increment!
 export log_histogram, log_value, log_vector, log_text, log_image, log_images,

--- a/src/event.jl
+++ b/src/event.jl
@@ -28,7 +28,7 @@ format. The format follows the following rule (in bytes)
 """
 function write_event(out::IOStream, event::Event)
     data = PipeBuffer();
-    logless_writeproto(data, event)
+    _writeproto(data, event)
 
     #header
     header     = collect(reinterpret(UInt8, [data.size]))

--- a/src/event.jl
+++ b/src/event.jl
@@ -28,7 +28,7 @@ format. The format follows the following rule (in bytes)
 """
 function write_event(out::IOStream, event::Event)
     data = PipeBuffer();
-    writeproto(data, event)
+    logless_writeproto(data, event)
 
     #header
     header     = collect(reinterpret(UInt8, [data.size]))

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -8,7 +8,7 @@ end
 
 function serialize_proto(data::ProtoType)
     pb = PipeBuffer()
-    writeproto(pb, data)
+    logless_writeproto(pb, data)
     pb.data
 end
 
@@ -16,4 +16,14 @@ function serialize_proto(data::Any)
     pb = PipeBuffer()
     write(pb, data)
     pb.data
+end
+
+"""
+    wrapper for writeproto that supresses logging to prevent infinite
+    recursion.
+"""
+function logless_writeproto(pb::IO, obj)
+    with_logger(NullLogger()) do
+        writeproto(pb, obj)
+    end
 end

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -8,7 +8,7 @@ end
 
 function serialize_proto(data::ProtoType)
     pb = PipeBuffer()
-    logless_writeproto(pb, data)
+    _writeproto(pb, data)
     pb.data
 end
 
@@ -22,7 +22,7 @@ end
     wrapper for writeproto that supresses logging to prevent infinite
     recursion.
 """
-function logless_writeproto(pb::IO, obj)
+function _writeproto(pb::IO, obj)
     with_logger(NullLogger()) do
         writeproto(pb, obj)
     end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -305,6 +305,15 @@ ENV["DATADEPS_ALWAYS_ACCEPT"] = true
         include("deserialization.jl")
     end
 
+    @testset "Debug level" begin
+        logger = TBLogger("tensorboard_logs/run", min_level=Logging.Debug)
+        with_logger(logger) do
+            @info "loss" loss=10.
+            @debug "loss" loss=10.
+        end
+        @test TensorBoardLogger.step(logger) == 2
+    end
+
     #cleanup
     rm(test_log_dir, force=true, recursive=true)
 


### PR DESCRIPTION
This PR addresses https://github.com/PhilipVinc/TensorBoardLogger.jl/issues/96, following the suggestion of @oxinabox.