### PR TITLE
Support prepend argument in TBLogger constructor

### DIFF
--- a/src/TBLogger.jl
+++ b/src/TBLogger.jl
@@ -20,6 +20,7 @@ export tb_append, tb_overwrite, tb_increment
 """
     TBLogger(logdir[, tb_increment]; 
             time=time(), 
+            prepend="",
             purge_step=nothing, 
             step_increment=1, 
             min_level=Logging.Info)
@@ -36,13 +37,14 @@ by tensorboard (usefull in the case of restarting a crashed computation).
 tensorboard.
 """
 function TBLogger(logdir="tensorboard_logs/run", overwrite=tb_increment;
-                  time=time(), 
+                  time=time(),
+                  prepend="",
                   purge_step::Union{Int,Nothing}=nothing,
                   step_increment = 1, 
                   min_level::LogLevel=Info)
 
     logdir = init_logdir(logdir, overwrite)
-    fpath, evfile = create_eventfile(logdir, purge_step, time)
+    fpath, evfile = create_eventfile(logdir, purge_step, time; prepend)
 
     all_files  = Dict(fpath => evfile)
     start_step = something(purge_step, 0)

--- a/src/TBLogger.jl
+++ b/src/TBLogger.jl
@@ -20,7 +20,7 @@ export tb_append, tb_overwrite, tb_increment
 """
     TBLogger(logdir[, tb_increment]; 
             time=time(), 
-            prepend="",
+            prefix="",
             purge_step=nothing, 
             step_increment=1, 
             min_level=Logging.Info)
@@ -30,6 +30,9 @@ argument specifies the behaviour if the `logdir` already exhists: the default
 choice `tb_increment` appends an increasing number 1,2... to `logdir`. Other
 choices are `tb_overwrite`, which overwrites the previous folder, and `tb_append`.
 
+Optional keyword argument `prefix` can be passed to prepend a path to the file
+name (note, not the log directory). See `create_eventfile()`
+
 If a `purge_step::Int` is passed, every step before `purge_step` will be ignored
 by tensorboard (usefull in the case of restarting a crashed computation).
 
@@ -38,13 +41,13 @@ tensorboard.
 """
 function TBLogger(logdir="tensorboard_logs/run", overwrite=tb_increment;
                   time=time(),
-                  prepend="",
+                  prefix="",
                   purge_step::Union{Int,Nothing}=nothing,
                   step_increment = 1, 
                   min_level::LogLevel=Info)
 
     logdir = init_logdir(logdir, overwrite)
-    fpath, evfile = create_eventfile(logdir, purge_step, time; prepend)
+    fpath, evfile = create_eventfile(logdir, purge_step, time; prepend = prefix)
 
     all_files  = Dict(fpath => evfile)
     start_step = something(purge_step, 0)

--- a/test/test_TBLogger.jl
+++ b/test/test_TBLogger.jl
@@ -20,10 +20,15 @@ test_log_dir = "test_logs/"
     tbl4 = TBLogger(test_log_dir*"run_2", tb_overwrite)
     @test !isfile(test_log_dir*"run_2/testfile")
     
+    # check custom file prefix
+    tbl5 = TBLogger(test_log_dir*"run_3"; time = 0, prefix = "test.")
+    @test isfile(test_log_dir*"run_3/test.events.out.tfevents.0.$(gethostname())")
+
     # close all event files
     close.(values(tbl1.all_files))
     close.(values(tbl2.all_files))
     close.(values(tbl4.all_files))
+    close.(values(tbl5.all_files))
 end
 
 @testset "create log directory" begin


### PR DESCRIPTION
I'm working on a project where I run multiple threads producing tensorboard events for the same run (sharing a log directory), each thread producing events for different tags. The `time()` based file naming mechanism isn't guaranteed to avoid, and in fact leads to, collisions under this use case. To resolve the problem I've added support for the existing `create_eventfile()` `prepend` argument to `TBLogger()`.

Appreciate your reviewing and considering this small change. Thanks