### PR TITLE
Support s3 paths

### DIFF
--- a/.github/workflows/UnitTest.yml
+++ b/.github/workflows/UnitTest.yml
@@ -51,6 +51,10 @@ jobs:
           PackageSpec(name="Plots", version="1.6"),
         ])
       shell: julia --project=. --startup=no --color=yes {0}
-
+    - name: "Test with Minio on v1.5+"
+      if: ${{ matrix.julia_version != '1.3' }}
+      run: |
+        using Pkg
+        Pkg.add("Minio")
+      shell: julia --project=. --startup=no --color=yes {0}
     - uses: julia-actions/julia-runtest@latest
-

--- a/.github/workflows/UnitTest.yml
+++ b/.github/workflows/UnitTest.yml
@@ -50,11 +50,8 @@ jobs:
           PackageSpec(name="Reexport", version="0.2"),
           PackageSpec(name="Plots", version="1.6"),
         ])
-      shell: julia --project=. --startup=no --color=yes {0}
-    - name: "Test with Minio on v1.5+"
-      if: ${{ matrix.julia_version != '1.3' }}
-      run: |
-        using Pkg
-        Pkg.add("Minio")
+        # Remove Minio from the test project
+        write("Project.toml", read(`grep -v '^Minio =' Project.toml`, String))
+        run(`sed -i -e 's/, "Minio"//' Project.toml`)
       shell: julia --project=. --startup=no --color=yes {0}
     - uses: julia-actions/julia-runtest@latest

--- a/Project.toml
+++ b/Project.toml
@@ -20,7 +20,6 @@ StatsBase = "0.27, 0.28, 0.29, 0.30, 0.31, 0.32, 0.33"
 julia = "1.3"
 
 [extras]
-Minio = "4281f0d9-7ae0-406e-9172-b7277c1efa20"
 ImageMagick = "6218d12a-5da1-5696-b52f-db25d2ecc6d1"
 LightGraphs = "093fc24a-ae57-5d10-9952-331d41423f4d"
 Logging = "56ddb016-857b-54e1-b83d-db4d58db5568"
@@ -34,4 +33,4 @@ ValueHistories = "98cad3c8-aec3-5f06-8e41-884608649ab7"
 WAV = "8149f6b0-98f6-5db9-b78f-408fbbb8ef88"
 
 [targets]
-test = ["Test", "MLDatasets", "TestImages", "ImageMagick", "Logging", "LightGraphs", "Plots", "PyPlot", "WAV", "Tracker", "ValueHistories", "Minio"]
+test = ["Test", "MLDatasets", "TestImages", "ImageMagick", "Logging", "LightGraphs", "Plots", "PyPlot", "WAV", "Tracker", "ValueHistories"]

--- a/Project.toml
+++ b/Project.toml
@@ -20,6 +20,7 @@ StatsBase = "0.27, 0.28, 0.29, 0.30, 0.31, 0.32, 0.33"
 julia = "1.3"
 
 [extras]
+Minio = "4281f0d9-7ae0-406e-9172-b7277c1efa20"
 ImageMagick = "6218d12a-5da1-5696-b52f-db25d2ecc6d1"
 LightGraphs = "093fc24a-ae57-5d10-9952-331d41423f4d"
 Logging = "56ddb016-857b-54e1-b83d-db4d58db5568"
@@ -33,4 +34,4 @@ ValueHistories = "98cad3c8-aec3-5f06-8e41-884608649ab7"
 WAV = "8149f6b0-98f6-5db9-b78f-408fbbb8ef88"
 
 [targets]
-test = ["Test", "MLDatasets", "TestImages", "ImageMagick", "Logging", "LightGraphs", "Plots", "PyPlot", "WAV", "Tracker", "ValueHistories"]
+test = ["Test", "MLDatasets", "TestImages", "ImageMagick", "Logging", "LightGraphs", "Plots", "PyPlot", "WAV", "Tracker", "ValueHistories", "Minio"]

--- a/src/Deserialization/deserialization.jl
+++ b/src/Deserialization/deserialization.jl
@@ -1,13 +1,13 @@
 export summary_iterator
 
 """
-    is_valid_event(f::IOStream) => Bool
+    is_valid_event(f::IO) => Bool
 
 Returns true if the stream points to a valid TensorBoard event, false overwise.
 This is accomplished by checeking the crc checksum on the header (first 8
 bytes) of the event.
 """
-function is_valid_event(f::IOStream)
+function is_valid_event(f::IO)
     eof(f) && return false
 
     header = read(f, 8)
@@ -23,13 +23,13 @@ end
 
 
 """
-    read_event(f::IOStream) => Event
+    read_event(f::IO) => Event
 
 Reads the stream `f`, assuming it's encoded according to TensorBoard format,
 and decodes a single event.
 This function assumes that `eof(f) == false`.
 """
-function read_event(f::IOStream)
+function read_event(f::IO)
     header = read(f, 8)
     crc_header = read(f, 4)
 
@@ -113,7 +113,7 @@ Iterator for iterating along a fstream.
 The optional argument `stop_at_step` tells at what step the iterator should stop.
 """
 struct TBEventFileIterator
-    fstream::IOStream
+    fstream::IO
     stop_at_step::Int
 end
 TBEventFileIterator(fstream) = TBEventFileIterator(fstream, typemax(Int))

--- a/src/TBLogger.jl
+++ b/src/TBLogger.jl
@@ -1,7 +1,7 @@
 mutable struct TBLogger <: AbstractLogger
-    logdir::String
-    file::IOStream
-    all_files::Dict{String, IOStream}
+    logdir::Any
+    file::IO
+    all_files::Dict{String, IO}
     global_step::Int
     step_increment::Int
     min_level::LogLevel
@@ -89,7 +89,7 @@ function init_logdir(logdir, overwrite=tb_increment)
 end
 
 """
-	create_eventfile(logdir, [purge_step=nothing; time=time()]) -> IOStream
+	create_eventfile(logdir, [purge_step=nothing; time=time()]) -> IO
 
 Creates a protobuffer events file in the logdir and returns the IO buffer for
 writing to it. If `purge_step::Int` is passed then a special event is written
@@ -144,14 +144,14 @@ logdir(lg::TBLogger)   = lg.logdir
 """
     get_file(lg::TBLogger) -> IOS
 
-Returns the main `file` IOStream object of Logger `lg`.
+Returns the main `file` IO object of Logger `lg`.
 """
 get_file(lg::TBLogger) = lg.file
 
 """
     get_file(lg, tags::String...) -> IOS
 
-Returns the `file` IOStream object of Logger `lg` writing to the tag
+Returns the `file` IO object of Logger `lg` writing to the tag
 `tags1/tags2.../tagsN`.
 """
 function get_file(lg::TBLogger, tags::String...)

--- a/src/TBLogger.jl
+++ b/src/TBLogger.jl
@@ -52,7 +52,7 @@ function TBLogger(logdir="tensorboard_logs/run", overwrite=tb_increment;
     all_files  = Dict(fpath => evfile)
     start_step = something(purge_step, 0)
 
-    TBLogger{typeof(logdir), typeof(ev_file)}(logdir, evfile, all_files, start_step, step_increment, min_level)
+    TBLogger{typeof(logdir), typeof(evfile)}(logdir, evfile, all_files, start_step, step_increment, min_level)
 end
 
 """

--- a/src/TBLogger.jl
+++ b/src/TBLogger.jl
@@ -1,7 +1,7 @@
-mutable struct TBLogger <: AbstractLogger
-    logdir::Any
-    file::IO
-    all_files::Dict{String, IO}
+mutable struct TBLogger{P,S} <: AbstractLogger
+    logdir::P
+    file::S
+    all_files::Dict{String, S}
     global_step::Int
     step_increment::Int
     min_level::LogLevel
@@ -52,7 +52,7 @@ function TBLogger(logdir="tensorboard_logs/run", overwrite=tb_increment;
     all_files  = Dict(fpath => evfile)
     start_step = something(purge_step, 0)
 
-    TBLogger(logdir, evfile, all_files, start_step, step_increment, min_level)
+    TBLogger{typeof(logdir), typeof(ev_file)}(logdir, evfile, all_files, start_step, step_increment, min_level)
 end
 
 """

--- a/src/event.jl
+++ b/src/event.jl
@@ -16,7 +16,7 @@ function make_event(logger::TBLogger, summary::GraphDef; step=TensorBoardLogger.
 end
 
 """
-    write_event(out::IOStream, event::Event)
+    write_event(out::IO, event::Event)
 
 Serializes the Event `event` to the `out` stream according to the TensorBoard
 format. The format follows the following rule (in bytes)
@@ -26,7 +26,7 @@ format. The format follows the following rule (in bytes)
 #3 16...N        -     serialized `event` as protobuffer
 #4 N..N+8      UInt32  masked_CRC of #3
 """
-function write_event(out::IOStream, event::Event)
+function write_event(out::IO, event::Event)
     data = PipeBuffer();
     _writeproto(data, event)
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -5,20 +5,23 @@ using TestImages
 using ImageCore
 using FileIO
 using LightGraphs
-using Minio
-
 
 ENV["DATADEPS_ALWAYS_ACCEPT"] = true
 ENV["GKSwstype"] = "100"
 ENV["DATADEPS_ALWAYS_ACCEPT"] = true
 
-# Setup Minio server to test s3 paths
-minio_server = Minio.Server(mktempdir(); address="localhost:9001")
-run(minio_server, wait=false)
-config = MinioConfig("http://localhost:9001")
-s3_create_bucket(config, "tensorboard-tests")
-s3_log_dir = S3Path("s3://tensorboard-tests/logdir/"; config=config)
+log_dirs = Any["test_logs/"]
 
+if VERSION >= v"1.5"
+    using Minio
+    # Setup Minio server to test s3 paths
+    minio_server = Minio.Server(mktempdir(); address="localhost:9001")
+    run(minio_server, wait=false)
+    config = MinioConfig("http://localhost:9001")
+    s3_create_bucket(config, "tensorboard-tests")
+    s3_log_dir = S3Path("s3://tensorboard-tests/logdir/"; config=config)
+    push!(log_dirs, s3_log_dir)
+end
 
 @testset "TensorBoardLogger with path $(test_log_dir)" for test_log_dir in ("test_logs/", s3_log_dir)
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -10,7 +10,7 @@ ENV["DATADEPS_ALWAYS_ACCEPT"] = true
 ENV["GKSwstype"] = "100"
 ENV["DATADEPS_ALWAYS_ACCEPT"] = true
 
-log_dirs = Any["test_logs/"]
+LOG_DIRS = Any["test_logs/"]
 
 if VERSION >= v"1.5"
     using Minio
@@ -20,10 +20,10 @@ if VERSION >= v"1.5"
     config = MinioConfig("http://localhost:9001")
     s3_create_bucket(config, "tensorboard-tests")
     s3_log_dir = S3Path("s3://tensorboard-tests/logdir/"; config=config)
-    push!(log_dirs, s3_log_dir)
+    push!(LOG_DIRS, s3_log_dir)
 end
 
-@testset "TensorBoardLogger with path $(test_log_dir)" for test_log_dir in ("test_logs/", s3_log_dir)
+@testset "TensorBoardLogger with path $(test_log_dir)" for test_log_dir in LOG_DIRS
 
     @testset "TBLogger" begin
         include("test_TBLogger.jl")
@@ -330,4 +330,6 @@ end
 
 end
 
-kill(minio_server)
+if VERSION >= v"1.5"
+    kill(minio_server)
+end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -5,21 +5,29 @@ using TestImages
 using ImageCore
 using FileIO
 using LightGraphs
+using Minio
 
-test_log_dir = "test_logs/"
+
 ENV["DATADEPS_ALWAYS_ACCEPT"] = true
 ENV["GKSwstype"] = "100"
-
 ENV["DATADEPS_ALWAYS_ACCEPT"] = true
 
-@testset "TensorBoardLogger" begin
+# Setup Minio server to test s3 paths
+minio_server = Minio.Server(mktempdir(); address="localhost:9001")
+run(minio_server, wait=false)
+config = MinioConfig("http://localhost:9001")
+s3_create_bucket(config, "tensorboard-tests")
+s3_log_dir = S3Path("s3://tensorboard-tests/logdir/"; config=config)
+
+
+@testset "TensorBoardLogger with path $(test_log_dir)" for test_log_dir in ("test_logs/", s3_log_dir)
 
     @testset "TBLogger" begin
         include("test_TBLogger.jl")
     end
 
     @testset "Scalar Value Logger" begin
-        logger = TBLogger(test_log_dir*"t", tb_overwrite)
+        logger = TBLogger(joinpath(test_log_dir, "t/"), tb_overwrite)
         step = 1
 
         ss = TensorBoardLogger.scalar_summary("test", 12.0)
@@ -49,7 +57,7 @@ ENV["DATADEPS_ALWAYS_ACCEPT"] = true
     end
 
     @testset "Histogram Value Logger" begin
-        logger = TBLogger(test_log_dir*"t", tb_overwrite)
+        logger = TBLogger(joinpath(test_log_dir, "t/"), tb_overwrite)
         step = 1
 
         x0 = 0.5+step/30; s0 = 0.5/(step/20);
@@ -96,7 +104,7 @@ ENV["DATADEPS_ALWAYS_ACCEPT"] = true
     end
 
     @testset "Text Logger" begin
-        logger = TBLogger(test_log_dir*"t", tb_overwrite)
+        logger = TBLogger(joinpath(test_log_dir, "t/"), tb_overwrite)
         step = 1
 
         ss = TensorBoardLogger.text_summary("test", "Hello World")
@@ -127,7 +135,7 @@ ENV["DATADEPS_ALWAYS_ACCEPT"] = true
     end
 
     @testset "Image Logger" begin
-        logger = TBLogger(test_log_dir*"t", tb_overwrite)
+        logger = TBLogger(joinpath(test_log_dir, "t/"), tb_overwrite)
         step = 1
 
         # The following tests are akin to @test_nothrow, which does not exist.
@@ -217,7 +225,7 @@ ENV["DATADEPS_ALWAYS_ACCEPT"] = true
     end
 
     @testset "LogInterface" begin
-        logger = TBLogger(test_log_dir*"t", tb_overwrite)
+        logger = TBLogger(joinpath(test_log_dir, "t/"), tb_overwrite)
         woman = testimage("woman_blonde")
         mri = testimage("mri")
         with_logger(logger) do
@@ -238,7 +246,7 @@ ENV["DATADEPS_ALWAYS_ACCEPT"] = true
     end
 
     @testset "Audio Logger" begin
-        logger = TBLogger(test_log_dir*"t", tb_overwrite)
+        logger = TBLogger(joinpath(test_log_dir, "t/"), tb_overwrite)
         step = 1
 
         ss = TensorBoardLogger.audio_summary("test", rand(800), 800)
@@ -255,7 +263,7 @@ ENV["DATADEPS_ALWAYS_ACCEPT"] = true
     end
 
     @testset "Graph Logger" begin
-        logger = TBLogger(test_log_dir*"t", tb_overwrite)
+        logger = TBLogger(joinpath(test_log_dir, "t/"), tb_overwrite)
         step = 1
         ss = TensorBoardLogger.graph_summary(DiGraph(1), ["1"], ["1"], ["cpu"], [nothing])
         @test isa(ss, TensorBoardLogger.GraphDef)
@@ -272,14 +280,14 @@ ENV["DATADEPS_ALWAYS_ACCEPT"] = true
     end
 
     @testset "Embedding Logger" begin
-        logger = TBLogger(test_log_dir*"t", tb_overwrite)
+        logger = TBLogger(joinpath(test_log_dir, "t/"), tb_overwrite)
         step = 1
         mat = rand(4, 4)
         metadata = rand(4, 10)
         metadata_header = Array(collect(1:10))
         imgs = TBImages(rand(8, 8, 3, 4), HWCN)
-        @test π != log_embeddings(logger, "random1", mat, metadata = metadata, metadata_header = metadata_header, img_labels = imgs, step = step)
-        @test π != log_embeddings(logger, "random2", mat, step = step+1)
+        @test π != log_embeddings(logger, "random1/", mat, metadata = metadata, metadata_header = metadata_header, img_labels = imgs, step = step)
+        @test π != log_embeddings(logger, "random2/", mat, step = step+1)
 
         close.(values(logger.all_files))
     end
@@ -318,3 +326,5 @@ ENV["DATADEPS_ALWAYS_ACCEPT"] = true
     rm(test_log_dir, force=true, recursive=true)
 
 end
+
+kill(minio_server)


### PR DESCRIPTION
Widens `IOStream` types to `IO` and `logdir::String` to `logdir::Any`. Runs all tests with both a local path and an `S3Path` (via Minio.jl which uses minio to run a local s3-like server).

Closes #102 

I had to change lots of `*` to `joinpath` to pass the config along correctly, and do a few other minor workarounds to get all the tests passing.