### PR TITLE
Changed URL for deployment of documentation

### DIFF
--- a/docs/make.jl
+++ b/docs/make.jl
@@ -22,5 +22,5 @@ makedocs(
 )
 
 deploydocs(
-    repo   = "github.com/PhilipVinc/TensorBoardLogger.jl.git",
+    repo   = "github.com/JuliaLogging/TensorBoardLogger.jl.git",
     target = "build")


### PR DESCRIPTION
Hopefully should fix https://github.com/JuliaLogging/TensorBoardLogger.jl/issues/111, but I am not 100% sure.