### PR TITLE
support only julia 1.6+

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -17,7 +17,7 @@ ImageCore = "0.8.1, 0.9"
 ProtoBuf = "0.10, 0.11"
 Requires = "0.5, 1"
 StatsBase = "0.27, 0.28, 0.29, 0.30, 0.31, 0.32, 0.33"
-julia = "1.3"
+julia = "1.6"
 
 [extras]
 Minio = "4281f0d9-7ae0-406e-9172-b7277c1efa20"


### PR DESCRIPTION
CI fails on julia 1.3. I think we shouldn't waste time trying to support julia versions so old, hence I bumped julia compact to v1.6. If people agree with the change I will go on and update the workflows appropriately.
