### PR TITLE
fix where clause warning

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "TensorBoardLogger"
 uuid = "899adc3e-224a-11e9-021f-63837185c80f"
 authors = ["Filippo Vicentini <filippovicentini@gmail.com>"]
-version = "0.1.19"
+version = "0.1.20"
 
 [deps]
 CRC32c = "8bf52ea8-c179-5cab-976a-9e18b702a9bc"

--- a/src/logger_dispatch.jl
+++ b/src/logger_dispatch.jl
@@ -70,7 +70,7 @@ summary_impl(name, value::PngImage) = image_summary(name, value)
 
 
 ########## For things going to LogText ##############################
-preprocess(name, val::AbstractString, data) where T<:String = push!(data, name=>val)
+preprocess(name, val::AbstractString, data) = push!(data, name=>val)
 summary_impl(name, value::Any) = text_summary(name, value)
 
 


### PR DESCRIPTION
This deletes a superfluous `where` clause that was causing a warning whenever TensorBoardLogger or one of its dependents would get imported.