### PR TITLE
Use tb_chart_type in docs

### DIFF
--- a/docs/src/explicit_interface.md
+++ b/docs/src/explicit_interface.md
@@ -44,7 +44,7 @@ See [TensorBoard Custom Scalar page](https://github.com/tensorflow/tensorboard/t
 
 For example, to combine in the same plot panel the two curves logged under tags `"Curve/1"` and `"Curve/2"` you can run once the command:
 ```julia
-layout = Dict("Cat" => Dict("Curve" => ("Multiline", ["Curve/1", "Curve/2"])))
+layout = Dict("Cat" => Dict("Curve" => (tb_multiline, ["Curve/1", "Curve/2"])))
 
 log_custom_scalar(lg, layout)
 


### PR DESCRIPTION
Fixes the [custom scalar plugin documentation](https://github.com/JuliaLogging/TensorBoardLogger.jl/blob/a29826a/docs/src/explicit_interface.md#custom-scalars-plugin) which does not use the [chart type enum](https://github.com/JuliaLogging/TensorBoardLogger.jl/blob/a29826a/src/Loggers/LogCustomScalar.jl).