### PR TITLE
Fix MultilineChartContent not defined

### DIFF
--- a/src/Loggers/LogCustomScalar.jl
+++ b/src/Loggers/LogCustomScalar.jl
@@ -1,3 +1,6 @@
+using .tensorboard_plugin_custom_scalar
+using .tensorboard_plugin_custom_scalar: var"MarginChartContent.Series" as MarginChartContent_Series
+
 # possible chart types
 @enum tb_chart_type tb_multiline=1 tb_margin=2
 


### PR DESCRIPTION
Calling the function [log_custom_scalar](https://julialogging.github.io/TensorBoardLogger.jl/dev/explicit_interface/#TensorBoardLogger.log_custom_scalar) results in an error:
```
ERROR: UndefVarError: `MultilineChartContent` not defined
```
This fixes the error by importing the missing undefined classes.

Those classes are defined in [src/protojl/tensorboard/plugins/custom_scalar/tensorboard/layout_pb.jl](https://github.com/JuliaLogging/TensorBoardLogger.jl/blob/e985f09/src/protojl/tensorboard/plugins/custom_scalar/tensorboard/layout_pb.jl).

This is similar to what was done in the file for the audio logger [src/Loggers/LogAudio.jl](https://github.com/JuliaLogging/TensorBoardLogger.jl/blob/e985f09/src/Loggers/LogAudio.jl#L1).