### PR TITLE
suppress warning due to unused type parameter

### DIFF
--- a/src/logger_dispatch.jl
+++ b/src/logger_dispatch.jl
@@ -76,7 +76,7 @@ summary_impl(name, value::Any) = text_summary(name, value)
 
 ########## For things going to LogHistograms ########################
 # Only consider 1D histograms for histogram plotting
-preprocess(name, hist::Histogram{T,1}, data) where T = push!(data, name=>hist)
+preprocess(name, hist::Histogram{<:Any,1}, data) = push!(data, name=>hist)
 summary_impl(name, hist::Histogram) = histogram_summary(name, hist)
 
 # TODO: maybe deprecate? tuple means histogram (only if bins/weights match)


### PR DESCRIPTION
Hopefully this should suppress the following precompilation warning:
```
WARNING: method definition for preprocess at  
/home/lucibello/.julia/packages/TensorBoardLogger/Ukp9t/src/logger_dispatch.jl:73 declares type variable T 
but does not use it.
```