### PR TITLE
Add support for sampling rate in audio logging

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -10,6 +10,7 @@ ImageCore = "a09fc81d-aa75-5fe9-8630-4744c3626534"
 ProtoBuf = "3349acd9-ac6a-5e09-bcdb-63829b23a429"
 Requires = "ae029012-a4dd-5104-9daa-d747884805df"
 StatsBase = "2913bbd2-ae8a-5f71-8c99-4fb6c76f3a91"
+WAV = "8149f6b0-98f6-5db9-b78f-408fbbb8ef88"
 
 [compat]
 FileIO = "1.2.3"
@@ -17,6 +18,7 @@ ImageCore = "0.8.1, 0.9, 0.10"
 ProtoBuf = "1.0.11"
 Requires = "0.5, 1"
 StatsBase = "0.27, 0.28, 0.29, 0.30, 0.31, 0.32, 0.33, 0.34"
+WAV = "1.2.0"
 julia = "1.6"
 
 [extras]

--- a/src/Loggers/LogAudio.jl
+++ b/src/Loggers/LogAudio.jl
@@ -1,4 +1,5 @@
 using .tensorboard: var"Summary.Audio" as Summary_Audio
+using WAV
 
 """
     log_audios(logger::TBLogger, name::AbstractString, samples::AbstractArray, samplerate::Real; step=step(logger))
@@ -30,8 +31,8 @@ function audio_summary(name::AbstractString, samples::AbstractArray, samplerate:
     samples = samples./max(maximum(samples), 1)
     samples = Int16.(floor.(samples.*32767))
     io = IOBuffer()
-    save(_format_stream(format"WAV",io), samples)
-    eas = io.data
+    wavwrite(samples, io; Fs=samplerate)
+    eas = take!(io) 
     audio = Summary_Audio(samplerate, ndims(samples), size(samples, 1), eas, "audio/wav")
     Summary_Value(name, name, nothing, OneOf(:audio, audio))
 end


### PR DESCRIPTION
Resolves #149 

TensorBoardLogger.jl currently writes WAVs and puts them in encoded_audio_string. That means TensorBoard will only pay attention to the sample rate stored in the WAV header. The sample rate is not written there however. It is not possible to include the header information in the `FileIO.stream`, hence using `wavwrite` and adding `WAV.jl` is necessary as this does support the sample rate argument.